### PR TITLE
Fix the bug which does not emit some modules as es module syntax into esm/.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## x.y.z
 
+### Bug fix
+
+- Fix the bug which does not emit some modules as ES module syntax into `esm/`. ([#201](https://github.com/karen-irc/option-t/pull/201))
+    - This fixes that some files in `option-t/esm` are not ES module.
+        - `option-t/esm`
+        - `option-t/esm/Option`
+        - `option-t/esm/Result`
+
 ### Internals
 
 - Clean up internals types. ([#200](https://github.com/karen-irc/option-t/pull/200))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ const MOCHA_CMD = 'mocha';
 const RENAME_CMD = 'rename';
 const TSC_CMD = 'tsc';
 
-const BABEL_PRD_TRANSFORMER_LIST = ['transform-es2015-modules-commonjs', 'transform-es2015-block-scoping'].join(',');
+const BABEL_PRD_TRANSFORMER_LIST = ['transform-es2015-block-scoping'];
 
 /**
  *  @param  {string}    cmd
@@ -90,7 +90,7 @@ gulp.task('build_cjs_js', ['clean_build_cjs'], () => {
         '--out-dir', './lib/',
         '--extensions=.js',
         '--no-babelrc',
-        '--plugins', BABEL_PRD_TRANSFORMER_LIST
+        '--plugins', ['transform-es2015-modules-commonjs', ...BABEL_PRD_TRANSFORMER_LIST].join(','),
     ]);
     return p;
 });


### PR DESCRIPTION
This fixes that some files in `option-t/esm` are not ES module.

- `option-t/esm`
- `option-t/esm/Option`
- `option-t/esm/Result`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/201)
<!-- Reviewable:end -->
