### PR TITLE
Add the alias for toOptionFromOk/toOptionFromErr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   - If you use `option-t/lib`, please replace it with `option-t/cjs`
 
 
+### Enhancement
+
+- You can use `import { ok, err, } from 'option-t/esm/PlainResult';` instead of `import { toOptionFromOk, toOptionFromErr, } from 'option-t/esm/PlainResult';`. ([#219](https://github.com/karen-irc/option-t/pull/219))
+
+
 ## 11.0.0
 
 ### Breaking Change

--- a/src/PlainResult/index.ts
+++ b/src/PlainResult/index.ts
@@ -29,6 +29,8 @@ export { orElseForResult as orElse } from './orElse';
 export {
     toOptionFromOk,
     toOptionFromErr,
+    toOptionFromOk as ok,
+    toOptionFromErr as err,
 } from './toOption';
 export {
     unwrapFromResult as unwrap,


### PR DESCRIPTION
You can use `import { ok, err, } from 'option-t/esm/PlainResult';` instead of `import { toOptionFromOk, toOptionFromErr, } from 'option-t/esm/PlainResult';`.

## Related Issues

- https://github.com/karen-irc/option-t/issues/217
- https://github.com/karen-irc/option-t/issues/216

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/219)
<!-- Reviewable:end -->
