### PR TITLE
Unship a source map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## x.y.z
 
+### Breaking Change
+
+- Unship a source map. ([#220](https://github.com/karen-irc/option-t/pull/220))
+    - Our shipping code is down-level transformed. But ours not a complicated transform. We can read the transformed code.
+    - For debugging purpose, Showing _transformed_ code would be better if it's not complicated.
+    - Thus We stop to ship a source map.
+
 
 ## 12.0.0
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -152,7 +152,6 @@ gulp.task('build_mjs_create_tmp_mjs', ['clean_tmp_mjs'], () => {
     const ts = execNpmCmd(TSC_CMD, [
         '-p', './tsconfig_esm.json',
         '--outDir', TMP_MJS_DIR,
-        '--sourceMap', 'false',
         '--declaration', 'false'
     ]);
 
@@ -190,7 +189,6 @@ gulp.task('test_preprocess', ['clean_test_cache'], () => {
         './test',
         '--out-dir', './__test_cache/',
         '--extensions=.js',
-        '--source-maps', 'inline',
     ]);
     return p;
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
         "pretty": true,
         "preserveConstEnums": true,
         "removeComments": false,
-        "sourceMap": true,
+        "sourceMap": false,
         "strict": true,
         "suppressImplicitAnyIndexErrors": false,
         "target": "es5"


### PR DESCRIPTION
- Our shipping code is down-level transformed. But ours not a complicated transform. We can read the transformed code.
- For debugging purpose, Showing _transformed_ code would be better if it's not complicated.
- Thus We stop to ship a source map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/220)
<!-- Reviewable:end -->
