### PR TITLE
Add tap() to sort with rxjs/ixjs

### DIFF
--- a/src/Maybe/do.ts
+++ b/src/Maybe/do.ts
@@ -1,7 +1,7 @@
-import { DoFn } from '../utils/Function';
+import { TapFn } from '../utils/Function';
 import { Maybe } from './Maybe';
 
-export function doOnMaybe<T>(v: Maybe<T>, fn: DoFn<T>): void {
+export function doOnMaybe<T>(v: Maybe<T>, fn: TapFn<T>): void {
     if (v === undefined || v === null) {
         return;
     }

--- a/src/Maybe/do.ts
+++ b/src/Maybe/do.ts
@@ -1,10 +1,3 @@
-import { TapFn } from '../utils/Function';
-import { Maybe } from './Maybe';
-
-export function doOnMaybe<T>(v: Maybe<T>, fn: TapFn<T>): void {
-    if (v === undefined || v === null) {
-        return;
-    }
-
-    fn(v);
-}
+export {
+    tapMaybe as doOnMaybe
+} from './tap';

--- a/src/Maybe/index.ts
+++ b/src/Maybe/index.ts
@@ -2,7 +2,7 @@ export * from './Maybe';
 // XXX: `and()` operation is equivalent of `a && b` so we don't ship it by default set.
 //export { andForMaybe as and } from './and';
 export { andThenForMaybe as andThen } from './andThen';
-export { doOnMaybe as do } from './do';
+export { tapMaybe as do } from './tap';
 export { expectNotNullAndUndefined as expect } from './expect';
 export { mapForMaybe as map } from './map';
 export { mapOrForMaybe as mapOr } from './mapOr';
@@ -10,6 +10,7 @@ export { mapOrElseForMaybe as mapOrElse } from './mapOrElse';
 // XXX: `or()` operation is equivalent of `a || b` so we don't ship it by default set.
 // export { orForMaybe as or } from './or';
 export { orElseForMaybe as orElse } from './orElse';
+export { tapMaybe as tap } from './tap';
 export { unwrapMaybe as unwrap } from './unwrap';
 export { unwrapOrFromMaybe as unwrapOr } from './unwrapOr';
 export { unwrapOrElseFromMaybe as unwrapOrElse } from './unwrapOrElse';

--- a/src/Maybe/tap.ts
+++ b/src/Maybe/tap.ts
@@ -1,0 +1,10 @@
+import { TapFn } from '../utils/Function';
+import { Maybe } from './Maybe';
+
+export function tapMaybe<T>(v: Maybe<T>, fn: TapFn<T>): void {
+    if (v === undefined || v === null) {
+        return;
+    }
+
+    fn(v);
+}

--- a/src/Nullable/do.ts
+++ b/src/Nullable/do.ts
@@ -1,7 +1,7 @@
-import { DoFn } from '../utils/Function';
+import { TapFn } from '../utils/Function';
 import { Nullable } from './Nullable';
 
-export function doOnNullable<T>(v: Nullable<T>, fn: DoFn<T>): void {
+export function doOnNullable<T>(v: Nullable<T>, fn: TapFn<T>): void {
     if (v === null) {
         return;
     }

--- a/src/Nullable/do.ts
+++ b/src/Nullable/do.ts
@@ -1,10 +1,3 @@
-import { TapFn } from '../utils/Function';
-import { Nullable } from './Nullable';
-
-export function doOnNullable<T>(v: Nullable<T>, fn: TapFn<T>): void {
-    if (v === null) {
-        return;
-    }
-
-    fn(v);
-}
+export {
+    tapNullable as doOnMaybe
+} from './tap';

--- a/src/Nullable/index.ts
+++ b/src/Nullable/index.ts
@@ -2,7 +2,7 @@ export * from './Nullable';
 // XXX: `and()` operation is equivalent of `a && b` so we don't ship it by default set.
 //export { andForNullable as and } from './and';
 export { andThenForNullable as andThen } from './andThen';
-export { doOnNullable as do } from './do';
+export { tapNullable as do } from './tap';
 export { expectNotNull as expect } from './expect';
 export { mapForNullable as map } from './map';
 export { mapOrForNullable as mapOr } from './mapOr';
@@ -10,6 +10,7 @@ export { mapOrElseForNullable as mapOrElse } from './mapOrElse';
 // XXX: `or()` operation is equivalent of `a || b` so we don't ship it by default set.
 // export { orForNullable as or } from './or';
 export { orElseForNullable as orElse } from './orElse';
+export { tapNullable as tap } from './tap';
 export { unwrapNullable as unwrap } from './unwrap';
 export { unwrapOrFromNullable as unwrapOr } from './unwrapOr';
 export { unwrapOrElseFromNullable as unwrapOrElse } from './unwrapOrElse';

--- a/src/Nullable/tap.ts
+++ b/src/Nullable/tap.ts
@@ -1,0 +1,10 @@
+import { TapFn } from '../utils/Function';
+import { Nullable } from './Nullable';
+
+export function tapNullable<T>(v: Nullable<T>, fn: TapFn<T>): void {
+    if (v === null) {
+        return;
+    }
+
+    fn(v);
+}

--- a/src/PlainOption/do.ts
+++ b/src/PlainOption/do.ts
@@ -1,10 +1,3 @@
-import { TapFn } from '../utils/Function';
-import { Option } from './Option';
-
-export function doOnOption<T>(v: Option<T>, fn: TapFn<T>): void {
-    if (!v.ok) {
-        return;
-    }
-
-    fn(v.val);
-}
+export {
+    tapOption as doOnMaybe
+} from './tap';

--- a/src/PlainOption/do.ts
+++ b/src/PlainOption/do.ts
@@ -1,7 +1,7 @@
-import { DoFn } from '../utils/Function';
+import { TapFn } from '../utils/Function';
 import { Option } from './Option';
 
-export function doOnOption<T>(v: Option<T>, fn: DoFn<T>): void {
+export function doOnOption<T>(v: Option<T>, fn: TapFn<T>): void {
     if (!v.ok) {
         return;
     }

--- a/src/PlainOption/index.ts
+++ b/src/PlainOption/index.ts
@@ -12,13 +12,14 @@ export {
 export { andForOption as and } from './and';
 export { andThenForOption as andThen } from './andThen';
 export { asMutOption as asMut } from './asMut';
-export { doOnOption as do } from './do';
+export { tapOption as do } from './tap';
 export { expectIsSome as expect } from './expect';
 export { mapForOption as map } from './map';
 export { mapOrForOption as mapOr } from './mapOr';
 export { mapOrElseForOption as mapOrElse } from './mapOrElse';
 export { orForOption as or } from './or';
 export { orElseForOption as orElse } from './orElse';
+export { tapOption as tap } from './tap';
 export { unwrapOption as unwrap } from './unwrap';
 export { unwrapOrFromOption as unwrapOr } from './unwrapOr';
 export { unwrapOrElseFromOption as unwrapOrElse } from './unwrapOrElse';

--- a/src/PlainOption/tap.ts
+++ b/src/PlainOption/tap.ts
@@ -1,0 +1,10 @@
+import { TapFn } from '../utils/Function';
+import { Option } from './Option';
+
+export function tapOption<T>(v: Option<T>, fn: TapFn<T>): void {
+    if (!v.ok) {
+        return;
+    }
+
+    fn(v.val);
+}

--- a/src/PlainResult/do.ts
+++ b/src/PlainResult/do.ts
@@ -1,17 +1,17 @@
-import { DoFn } from '../utils/Function';
+import { TapFn } from '../utils/Function';
 import { Result } from './Result';
 
 function noop<T>(_v: T) {}
 
-export function doOnOk<T, E>(v: Result<T, E>, fn: DoFn<T>): void {
+export function doOnOk<T, E>(v: Result<T, E>, fn: TapFn<T>): void {
     return doOnBoth(v, fn, noop);
 }
 
-export function doOnErr<T, E>(v: Result<T, E>, fn: DoFn<E>): void {
+export function doOnErr<T, E>(v: Result<T, E>, fn: TapFn<E>): void {
     return doOnBoth(v, noop, fn);
 }
 
-export function doOnBoth<T, E>(src: Result<T, E>, okFn: DoFn<T>, errFn: DoFn<E>): void {
+export function doOnBoth<T, E>(src: Result<T, E>, okFn: TapFn<T>, errFn: TapFn<E>): void {
     if (src.ok) {
         okFn(src.val);
     }

--- a/src/PlainResult/do.ts
+++ b/src/PlainResult/do.ts
@@ -1,21 +1,5 @@
-import { TapFn } from '../utils/Function';
-import { Result } from './Result';
-
-function noop<T>(_v: T) {}
-
-export function doOnOk<T, E>(v: Result<T, E>, fn: TapFn<T>): void {
-    return doOnBoth(v, fn, noop);
-}
-
-export function doOnErr<T, E>(v: Result<T, E>, fn: TapFn<E>): void {
-    return doOnBoth(v, noop, fn);
-}
-
-export function doOnBoth<T, E>(src: Result<T, E>, okFn: TapFn<T>, errFn: TapFn<E>): void {
-    if (src.ok) {
-        okFn(src.val);
-    }
-    else {
-        errFn(src.err);
-    }
-}
+export {
+    tapOk as doOnOk,
+    tapErr as doOnErr,
+    tapBoth as doOnBoth,
+} from './tap';

--- a/src/PlainResult/index.ts
+++ b/src/PlainResult/index.ts
@@ -14,10 +14,10 @@ export { andForResult as and } from './and';
 export { andThenForResult as andThen } from './andThen';
 export { asMutResult as asMut } from './asMut';
 export {
-    doOnOk,
-    doOnErr,
-    doOnBoth,
-} from './do';
+    tapOk as doOnOk,
+    tapErr as doOnErr,
+    tapBoth as doOnBoth,
+} from './tap';
 export {
     expectIsOk as expect,
     expectIsErr as expectErr,
@@ -26,6 +26,11 @@ export { mapForResult as map } from './map';
 export { mapErrForResult as mapErr } from './mapErr';
 export { orForResult as or } from './or';
 export { orElseForResult as orElse } from './orElse';
+export {
+    tapOk,
+    tapErr,
+    tapBoth,
+} from './tap';
 export {
     toOptionFromOk,
     toOptionFromErr,

--- a/src/PlainResult/tap.ts
+++ b/src/PlainResult/tap.ts
@@ -1,0 +1,21 @@
+import { TapFn } from '../utils/Function';
+import { Result } from './Result';
+
+function noop<T>(_v: T) {}
+
+export function tapOk<T, E>(v: Result<T, E>, fn: TapFn<T>): void {
+    return tapBoth(v, fn, noop);
+}
+
+export function tapErr<T, E>(v: Result<T, E>, fn: TapFn<E>): void {
+    return tapBoth(v, noop, fn);
+}
+
+export function tapBoth<T, E>(src: Result<T, E>, okFn: TapFn<T>, errFn: TapFn<E>): void {
+    if (src.ok) {
+        okFn(src.val);
+    }
+    else {
+        errFn(src.err);
+    }
+}

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -26,7 +26,7 @@ import {Option, Some, None} from './Option';
 import {
     MapFn,
     RecoveryWithErrorFn,
-    DoFn
+    TapFn
 } from './utils/Function';
 
 type FlatmapOkFn<T, U, E> = (this: void, v: T) => Result<U, E>;
@@ -146,7 +146,7 @@ export abstract class ResultBase<T, E> {
      *  @param  errDestructor
      *      This would be called with the inner value if self is `Err<E>`.
      */
-    abstract drop(destructor?: DoFn<T>, errDestructor?: DoFn<E>): void;
+    abstract drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
 interface Ok<T, E> extends ResultBase<T, E> {
@@ -165,7 +165,7 @@ interface Ok<T, E> extends ResultBase<T, E> {
     unwrapOr(optb: T): T;
     unwrapOrElse(op: RecoveryWithErrorFn<E, T>): T;
     expect(message: string): T;
-    drop(destructor?: DoFn<T>, errDestructor?: DoFn<E>): void;
+    drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
 interface OkConstructor {
@@ -193,7 +193,7 @@ interface Err<T, E> extends ResultBase<T, E> {
     unwrapOr(optb: T): T;
     unwrapOrElse(op: RecoveryWithErrorFn<E, T>): T;
     expect(message: string): never;
-    drop(destructor?: DoFn<T>, errDestructor?: DoFn<E>): void;
+    drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
 interface ErrConstructor {

--- a/src/Undefinable/do.ts
+++ b/src/Undefinable/do.ts
@@ -1,10 +1,3 @@
-import { TapFn } from '../utils/Function';
-import { Undefinable } from './Undefinable';
-
-export function doOnUndefinable<T>(v: Undefinable<T>, fn: TapFn<T>): void {
-    if (v === undefined) {
-        return;
-    }
-
-    fn(v);
-}
+export {
+    tapUndefinable as doOnMaybe
+} from './tap';

--- a/src/Undefinable/do.ts
+++ b/src/Undefinable/do.ts
@@ -1,7 +1,7 @@
-import { DoFn } from '../utils/Function';
+import { TapFn } from '../utils/Function';
 import { Undefinable } from './Undefinable';
 
-export function doOnUndefinable<T>(v: Undefinable<T>, fn: DoFn<T>): void {
+export function doOnUndefinable<T>(v: Undefinable<T>, fn: TapFn<T>): void {
     if (v === undefined) {
         return;
     }

--- a/src/Undefinable/index.ts
+++ b/src/Undefinable/index.ts
@@ -2,7 +2,7 @@ export * from './Undefinable';
 // XXX: `and()` operation is equivalent of `a && b` so we don't ship it by default set.
 //export { andForUndefinable as and} from './and';
 export { andThenForUndefinable as andThen} from './andThen';
-export { doOnUndefinable as do } from './do';
+export { tapUndefinable as do } from './tap';
 export { expectNotUndefined as expect } from './expect';
 export { mapForUndefinable as map } from './map';
 export { mapOrForUndefinable as mapOr } from './mapOr';
@@ -10,6 +10,7 @@ export { mapOrElseForUndefinable as mapOrElse } from './mapOrElse';
 // XXX: `or()` operation is equivalent of `a || b` so we don't ship it by default set.
 // export { orForUndefinable as or} from './or';
 export { orElseForUndefinable as orElse} from './orElse';
+export { tapUndefinable as tap } from './tap';
 export { unwrapUndefinable as unwrap } from './unwrap';
 export { unwrapOrFromUndefinable as unwrapOr } from './unwrapOr';
 export { unwrapOrElseFromUndefinable as unwrapOrElse } from './unwrapOrElse';

--- a/src/Undefinable/tap.ts
+++ b/src/Undefinable/tap.ts
@@ -1,0 +1,10 @@
+import { TapFn } from '../utils/Function';
+import { Undefinable } from './Undefinable';
+
+export function tapUndefinable<T>(v: Undefinable<T>, fn: TapFn<T>): void {
+    if (v === undefined) {
+        return;
+    }
+
+    fn(v);
+}

--- a/src/utils/Function.ts
+++ b/src/utils/Function.ts
@@ -1,4 +1,7 @@
 export type MapFn<T, U> = (this: void, v: T) => U;
 export type RecoveryFn<T> = (this: void) => T;
 export type RecoveryWithErrorFn<E, T> = (this: void, e: E) => T;
+export type TapFn<T> = (this: void, v: T) => void;
+
+// This type has been deprecated. This will be removed by https://github.com/karen-irc/option-t/issues/228
 export type DoFn<T> = (this: void, v: T) => void;


### PR DESCRIPTION
We rename `do()` functions to `tap()` at all to sort with [`rxjs`](https://github.com/ReactiveX/rxjs)
or [`ixjs`](https://github.com/ReactiveX/IxJS).
We leave `do()` as an alias for `tap()` with a backward compatibility.
You code will works well if you don't change your code on updating this version.

_But it will be gone in the next major release_. We recommends to change your code.
Basic migration guides is here:

- Instead of `DoFn`, import `TapFn` from `option-t/***utils/Function`.
- If you use `import { doOnA } from 'option-t/***/A/do';`, instead use `import { tapA } from 'option-t/***/A/tap';`.
- If you use `import AMod from 'option-t/***/A'; AMod.do();`, instead use `import AMod from 'option-t/***/A'; AMod.tap();`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/229)
<!-- Reviewable:end -->
