### PR TITLE
Add the comment why we check the returned value type from selector in map operation

### DIFF
--- a/src/Maybe/map.ts
+++ b/src/Maybe/map.ts
@@ -5,7 +5,12 @@ import { Maybe } from './Maybe';
 
 export function mapForMaybe<T, U>(src: Maybe<T>, selector: MapFn<T, U>): Maybe<U> {
     if (src !== undefined && src !== null) {
-        const r = selector(src);
+        const r: U = selector(src);
+        // XXX:
+        // If `U` is `Maybe<SomeType>`, we think naturally the returned value of this function would be
+        // the nested type `Maybe<Maybe<SomeType>>`. But this type means `(SomeType | null | undefined) | null | undefined`.
+        // So a type checker would recognize this type as `SomeType | null | undefined`. So it's flattened.
+        // Then the user should call `andThen` (_flatmap_) operation instead of this.
         return expectNotNullAndUndefined(r, ERR_MSG_SELECTOR);
     }
     else {

--- a/src/Nullable/map.ts
+++ b/src/Nullable/map.ts
@@ -6,6 +6,11 @@ import { Nullable } from './Nullable';
 export function mapForNullable<T, U>(src: Nullable<T>, selector: MapFn<T, U>): Nullable<U> {
     if (src !== null) {
         const r = selector(src);
+        // XXX:
+        // If `U` is `Nullable<SomeType>`, we think naturally the returned value of this function would be
+        // the nested type `Nullable<Nullable<SomeType>>`. But this type means `(SomeType | null) | null`.
+        // So a type checker would recognize this type as `SomeType | null`. So it's flattened.
+        // Then the user should call `andThen` (_flatmap_) operation instead of this.
         return expectNotNull(r, ERR_MSG_SELECTOR);
     }
     else {

--- a/src/Undefinable/map.ts
+++ b/src/Undefinable/map.ts
@@ -6,6 +6,11 @@ import { Undefinable } from './Undefinable';
 export function mapForUndefinable<T, U>(src: Undefinable<T>, selector: MapFn<T, U>): Undefinable<U> {
     if (src !== undefined) {
         const r = selector(src);
+        // XXX:
+        // If `U` is `Undefinable<SomeType>`, we think naturally the returned value of this function would be
+        // the nested type `Undefinable<Undefinable<SomeType>>`. But this type means `(SomeType | undefined) | undefined`.
+        // So a type checker would recognize this type as `SomeType | undefined`. So it's flattened.
+        // Then the user should call `andThen` (_flatmap_) operation instead of this.
         return expectNotUndefined(r, ERR_MSG_SELECTOR);
     }
     else {


### PR DESCRIPTION
If `U` is `Maybe<SomeType>`, we think naturally the returned value of this function would be
the nested type `Maybe<Maybe<SomeType>>`. But this type means `(SomeType | null | undefined) | null | undefined`.
So a type checker would recognize this type as `SomeType | null | undefined`. So it's flattened.
Then the user should call `andThen` (_flatmap_) operation instead of this.

And we should throw the error for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/236)
<!-- Reviewable:end -->
