### PR TITLE
Add the jsdoc to constructors which are planned to deprecate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## x.y.z
 
+### Documentations
+
+- Add the jsdoc comment to constructors which are planned to deprecate in ([#232]( https://github.com/karen-irc/option-t/issues/232)).
+ ([#277](https://github.com/karen-irc/option-t/pull/277))
+
 
 ## 15.0.0
 

--- a/src/Option.d.ts
+++ b/src/Option.d.ts
@@ -205,6 +205,10 @@ interface Some<T> extends OptionBase<T> {
     drop(destructor?: TapFn<T>): void;
 }
 
+/**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createSome()`.
+ */
 interface SomeConstructor {
     new<T>(v: T): Option<T>;
     readonly prototype: Some<any>; // tslint:disable-line:no-any
@@ -228,6 +232,10 @@ interface None<T> extends OptionBase<T> {
     drop(destructor?: TapFn<T>): void;
 }
 
+/**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createNone()`.
+ */
 interface NoneConstructor {
     new<T>(): Option<T>;
     readonly prototype: None<any>; // tslint:disable-line:no-any
@@ -239,7 +247,15 @@ interface NoneConstructor {
  */
 export type Option<T> = Some<T> | None<T>;
 
+/**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createSome()`.
+ */
 export declare const Some: SomeConstructor;
+/**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createNone()`.
+ */
 export declare const None: NoneConstructor;
 
 export declare function createSome<T>(val: T): Some<T>;

--- a/src/Option.js
+++ b/src/Option.js
@@ -279,6 +279,9 @@ OptionBase.prototype = Object.freeze({
 });
 
 /**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createSome()`.
+ *
  *  @constructor
  *  @template   T
  *  @extends    {OptionT<T>}
@@ -302,6 +305,9 @@ export function Some(val) {
 Some.prototype = new OptionBase();
 
 /**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createNone()`.
+ *
  *  @constructor
  *  @template   T
  *  @extends    {OptionT<T>}

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -168,6 +168,10 @@ interface Ok<T, E> extends ResultBase<T, E> {
     drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
+/**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createOk()`.
+ */
 interface OkConstructor {
     new<T, E>(v: T): Result<T, E>;
     readonly prototype: Ok<any, any>; // tslint:disable-line:no-any
@@ -196,6 +200,10 @@ interface Err<T, E> extends ResultBase<T, E> {
     drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
+/**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createErr()`.
+ */
 interface ErrConstructor {
     new<T, E>(e: E): Result<T, E>;
     readonly prototype: Err<any, any>; // tslint:disable-line:no-any
@@ -207,7 +215,15 @@ interface ErrConstructor {
  */
 export type Result<T, E> = Ok<T, E> | Err<T, E>;
 
+/**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createOk()`.
+ */
 export declare const Ok: OkConstructor;
+/**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createErr()`.
+ */
 export declare const Err: ErrConstructor;
 
 export declare function createOk<T, E>(val: T): Ok<T, E>;

--- a/src/Result.js
+++ b/src/Result.js
@@ -291,6 +291,9 @@ ResultBase.prototype = Object.freeze({
 });
 
 /**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createOk()`.
+ *
  *  @constructor
  *  @template   T, E
  *  @extends    {ResultBase<T, E>}
@@ -323,6 +326,9 @@ export function Ok(v) {
 Ok.prototype = new ResultBase();
 
 /**
+ *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
+ *  Instead, please use `createErr()`.
+ *
  *  @constructor
  *  @template   T, E
  *  @extends    {ResultBase<T, E>}


### PR DESCRIPTION
see https://github.com/karen-irc/option-t/issues/232

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/277)
<!-- Reviewable:end -->
