### PR TITLE
Obsolete instanceof checking for Option/Result 

### DIFF
--- a/src/Option.d.ts
+++ b/src/Option.d.ts
@@ -31,6 +31,138 @@ import {
 export type FlatmapFn<T, U> = MapFn<T, Option<U>>;
 export type MayRecoveryFn<T> = RecoveryFn<Option<T>>;
 
+interface Optionable<T> {
+    /**
+     *  Return whether the self is `Some<T>` or not.
+     */
+    readonly isSome: boolean;
+
+    /**
+     *  Return whether the self is `None` or not.
+     */
+    readonly isNone: boolean;
+
+    /**
+     *  Return the inner `T` of a `Some<T>`.
+     *
+     *  @throws {Error}
+     *      Throws if the self is a `None`.
+     */
+    unwrap(): T | never;
+
+    /**
+     *  Return the contained value or a default value `def`.
+     *
+     *  @param  def
+     *      The default value which is used if the self is a `None`.
+     */
+    unwrapOr(def: T): T;
+
+    /**
+     *  Return the contained value or compute it from a closure `fn`.
+     *
+     *  @param fn
+     *      The function which produces a default value which is used if the self is a `None`.
+     */
+    unwrapOrElse(fn: RecoveryFn<T>): T;
+
+    /**
+     *  Return the inner `T` of a `Some<T>`.
+     *
+     *  @param  msg
+     *      The error message which is used if the self is a `None`.
+     *  @throws {Error}
+     *      Throws a custom error with provided `msg`
+     *      if the self value equals `None`.
+     */
+    expect(msg: string): T | never;
+
+    /**
+     *  Map an `Option<T>` to `Option<U>` by applying a function to the contained value.
+     *
+     *  @param  fn
+     *      The function which is applied to the contained value and return the result
+     *      if the self is a `Some<T>`.
+     */
+    map<U>(fn: MapFn<T, U>): Option<U>;
+
+    /**
+     *  Return `None` if the self is `None`,
+     *  otherwise call `fn` with the wrapped value and return the result.
+     *
+     *  @param  fn
+     *      The function which is applied to the contained value and return the result
+     *      if the self is a `Some<T>`. This result will be flattened once.
+     */
+    flatMap<U>(fn: FlatmapFn<T, U>): Option<U>;
+
+    /**
+     *  Apply a function `fn` to the contained value or return a default `def`.
+     *
+     *  @param  def
+     *      The default value which is used if the self is a `None`.
+     *  @param  fn
+     *      The function which is applied to the contained value and return the result
+     *      if the self is a `Some<T>`.
+     */
+    mapOr<U>(def: U, fn: MapFn<T, U>): U;
+
+    /**
+     *  Apply a function `fn` to the contained value or produce a default result by `defFn`.
+     *
+     *  @param  defFn
+     *      The function which produces a default value which is used if the self is a `None`.
+     *  @param  fn
+     *      The function which is applied to the contained value and return the result
+     *      if the self is a `Some<T>`.
+     */
+    mapOrElse<U>(def: RecoveryFn<U>, fn: MapFn<T, U>): U;
+
+    /**
+     *  Return the passed value if the self is `Some<T>`,
+     *  otherwise return `None`.
+     *
+     *  @param  optb
+     *      The value which is returned if the self is a `Some<T>`.
+     */
+    and<U>(optb: Option<U>): Option<U>;
+
+    /**
+     *  The alias of `Option<T>.flatMap()`.
+     *
+     *  @param  fn
+     */
+    andThen<U>(fn: FlatmapFn<T, U>): Option<U>;
+
+    /**
+     *  Return the self if it contains a value, otherwise return `optb`.
+     *
+     *  @param  optb
+     *      The default value which is used if the self is a `None`.
+     */
+    or(optb: Option<T>): Option<T>;
+
+    /**
+     *  Return the self if it contains a value,
+     *  otherwise call `fn` and returns the result.
+     *
+     *  @param  fn
+     *      The function which produces a default value which is used if the self is a `None`.
+     */
+    orElse(fn: MayRecoveryFn<T>): Option<T>;
+
+    /**
+     *  Finalize the self.
+     *  After this is called, the object's behavior is not defined.
+     *
+     *  This method is inspired by Rust's `Drop` trait.
+     *
+     *  @param  destructor
+     *      This would be called with the inner value if self is `Some<T>`.
+     */
+    drop(destructor?: TapFn<T>): void;
+}
+
 /**
  *  The base object of `Some<T>` and `None<T>`.
  *
@@ -50,150 +182,18 @@ export type MayRecoveryFn<T> = RecoveryFn<Option<T>>;
  *  See also:
  *  https://github.com/karen-irc/option-t/pull/77
  */
-export abstract class OptionBase<T> {
+export abstract class OptionBase<T> implements Optionable<T> {
     private readonly ok: boolean;
     private readonly val: T | undefined;
 
-    /**
-     *  Return whether the self is `Some<T>` or not.
-     */
-    abstract readonly isSome: boolean;
+    protected constructor(ok: boolean, val: T | undefined);
 
-    /**
-     *  Return whether the self is `None` or not.
-     */
-    abstract readonly isNone: boolean;
-
-    /**
-     *  Return the inner `T` of a `Some<T>`.
-     *
-     *  @throws {Error}
-     *      Throws if the self is a `None`.
-     */
-    abstract unwrap(): T | never;
-
-    /**
-     *  Return the contained value or a default value `def`.
-     *
-     *  @param  def
-     *      The default value which is used if the self is a `None`.
-     */
-    abstract unwrapOr(def: T): T;
-
-    /**
-     *  Return the contained value or compute it from a closure `fn`.
-     *
-     *  @param fn
-     *      The function which produces a default value which is used if the self is a `None`.
-     */
-    abstract unwrapOrElse(fn: RecoveryFn<T>): T;
-
-    /**
-     *  Return the inner `T` of a `Some<T>`.
-     *
-     *  @param  msg
-     *      The error message which is used if the self is a `None`.
-     *  @throws {Error}
-     *      Throws a custom error with provided `msg`
-     *      if the self value equals `None`.
-     */
-    abstract expect(msg: string): T | never;
-
-    /**
-     *  Map an `Option<T>` to `Option<U>` by applying a function to the contained value.
-     *
-     *  @param  fn
-     *      The function which is applied to the contained value and return the result
-     *      if the self is a `Some<T>`.
-     */
-    abstract map<U>(fn: MapFn<T, U>): Option<U>;
-
-    /**
-     *  Return `None` if the self is `None`,
-     *  otherwise call `fn` with the wrapped value and return the result.
-     *
-     *  @param  fn
-     *      The function which is applied to the contained value and return the result
-     *      if the self is a `Some<T>`. This result will be flattened once.
-     */
-    abstract flatMap<U>(fn: FlatmapFn<T, U>): Option<U>;
-
-    /**
-     *  Apply a function `fn` to the contained value or return a default `def`.
-     *
-     *  @param  def
-     *      The default value which is used if the self is a `None`.
-     *  @param  fn
-     *      The function which is applied to the contained value and return the result
-     *      if the self is a `Some<T>`.
-     */
-    abstract mapOr<U>(def: U, fn: MapFn<T, U>): U;
-
-    /**
-     *  Apply a function `fn` to the contained value or produce a default result by `defFn`.
-     *
-     *  @param  defFn
-     *      The function which produces a default value which is used if the self is a `None`.
-     *  @param  fn
-     *      The function which is applied to the contained value and return the result
-     *      if the self is a `Some<T>`.
-     */
-    abstract mapOrElse<U>(def: RecoveryFn<U>, fn: MapFn<T, U>): U;
-
-    /**
-     *  Return the passed value if the self is `Some<T>`,
-     *  otherwise return `None`.
-     *
-     *  @param  optb
-     *      The value which is returned if the self is a `Some<T>`.
-     */
-    abstract and<U>(optb: Option<U>): Option<U>;
-
-    /**
-     *  The alias of `Option<T>.flatMap()`.
-     *
-     *  @param  fn
-     */
-    abstract andThen<U>(fn: FlatmapFn<T, U>): Option<U>;
-
-    /**
-     *  Return the self if it contains a value, otherwise return `optb`.
-     *
-     *  @param  optb
-     *      The default value which is used if the self is a `None`.
-     */
-    abstract or(optb: Option<T>): Option<T>;
-
-    /**
-     *  Return the self if it contains a value,
-     *  otherwise call `fn` and returns the result.
-     *
-     *  @param  fn
-     *      The function which produces a default value which is used if the self is a `None`.
-     */
-    abstract orElse(fn: MayRecoveryFn<T>): Option<T>;
-
-    /**
-     *  Finalize the self.
-     *  After this is called, the object's behavior is not defined.
-     *
-     *  This method is inspired by Rust's `Drop` trait.
-     *
-     *  @param  destructor
-     *      This would be called with the inner value if self is `Some<T>`.
-     */
-    abstract drop(destructor?: TapFn<T>): void;
-
-    abstract toJSON(): object;
-}
-
-interface Some<T> extends OptionBase<T> {
-    readonly isSome: true;
-    readonly isNone: false;
-    unwrap(): T;
+    readonly isSome: boolean;
+    readonly isNone: boolean;
+    unwrap(): T | never;
     unwrapOr(def: T): T;
     unwrapOrElse(fn: RecoveryFn<T>): T;
-    expect(msg: string): T;
+    expect(msg: string): T | never;
     map<U>(fn: MapFn<T, U>): Option<U>;
     flatMap<U>(fn: FlatmapFn<T, U>): Option<U>;
     mapOr<U>(def: U, fn: MapFn<T, U>): U;
@@ -203,6 +203,14 @@ interface Some<T> extends OptionBase<T> {
     or(optb: Option<T>): Option<T>;
     orElse(fn: MayRecoveryFn<T>): Option<T>;
     drop(destructor?: TapFn<T>): void;
+    toJSON(): { is_some: boolean; value: T | undefined  };
+}
+
+interface Some<T> extends Optionable<T> {
+    readonly isSome: true;
+    readonly isNone: false;
+    unwrap(): T;
+    expect(msg: string): T;
 }
 
 /**
@@ -210,26 +218,15 @@ interface Some<T> extends OptionBase<T> {
  *  Instead, please use `createSome()`.
  */
 interface SomeConstructor {
-    new<T>(v: T): Option<T>;
+    new <T>(v: T): Option<T>;
     readonly prototype: OptionBase<any>; // tslint:disable-line:no-any
 }
 
-interface None<T> extends OptionBase<T> {
+interface None<T> extends Optionable<T> {
     readonly isSome: false;
     readonly isNone: true;
     unwrap(): never;
-    unwrapOr(def: T): T;
-    unwrapOrElse(fn: RecoveryFn<T>): T;
     expect(msg: string): never;
-    map<U>(fn: MapFn<T, U>): Option<U>;
-    flatMap<U>(fn: FlatmapFn<T, U>): Option<U>;
-    mapOr<U>(def: U, fn: MapFn<T, U>): U;
-    mapOrElse<U>(def: RecoveryFn<U>, fn: MapFn<T, U>): U;
-    and<U>(optb: Option<U>): Option<U>;
-    andThen<U>(fn: FlatmapFn<T, U>): Option<U>;
-    or(optb: Option<T>): Option<T>;
-    orElse(fn: MayRecoveryFn<T>): Option<T>;
-    drop(destructor?: TapFn<T>): void;
 }
 
 /**
@@ -237,7 +234,7 @@ interface None<T> extends OptionBase<T> {
  *  Instead, please use `createNone()`.
  */
 interface NoneConstructor {
-    new<T>(): Option<T>;
+    new <T>(): Option<T>;
     readonly prototype: OptionBase<any>; // tslint:disable-line:no-any
 }
 

--- a/src/Option.d.ts
+++ b/src/Option.d.ts
@@ -211,7 +211,7 @@ interface Some<T> extends OptionBase<T> {
  */
 interface SomeConstructor {
     new<T>(v: T): Option<T>;
-    readonly prototype: Some<any>; // tslint:disable-line:no-any
+    readonly prototype: OptionBase<any>; // tslint:disable-line:no-any
 }
 
 interface None<T> extends OptionBase<T> {
@@ -238,7 +238,7 @@ interface None<T> extends OptionBase<T> {
  */
 interface NoneConstructor {
     new<T>(): Option<T>;
-    readonly prototype: None<any>; // tslint:disable-line:no-any
+    readonly prototype: OptionBase<any>; // tslint:disable-line:no-any
 }
 
 /**

--- a/src/Option.js
+++ b/src/Option.js
@@ -25,6 +25,8 @@
 /**
  *  @constructor
  *  @template   T
+ *  @param  {boolean}   ok
+ *  @param  {T|undefined} val
  *
  *  A base object of `Option<T>`.
  *  This is only used to `option instanceof OptionT`
@@ -32,7 +34,19 @@
  *
  *  The usecase example is a `React.PropTypes.
  */
-export function OptionBase() {}// eslint-disable-line no-empty-function
+export function OptionBase(ok, val) {
+    /**
+     *  @private
+     *  @type   {boolean}
+     */
+    this.ok = ok;
+
+    /**
+     *  @private
+     *  @type   {T|undefined}
+     */
+    this.val = val;
+}
 OptionBase.prototype = Object.freeze({
     /**
      *  Return whether this is `Some<T>` or not.
@@ -289,20 +303,10 @@ OptionBase.prototype = Object.freeze({
  *  @param  {T}   val
  */
 export function Some(val) {
-    /**
-     *  @private
-     *  @type   {boolean}
-     */
-    this.ok = true;
-
-    /**
-     *  @private
-     *  @type   {T}
-     */
-    this.val = val;
-    Object.seal(this);
+    const o = new OptionBase(true, val);
+    Object.seal(o);
+    return o;
 }
-Some.prototype = new OptionBase();
 
 /**
  *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
@@ -313,20 +317,10 @@ Some.prototype = new OptionBase();
  *  @extends    {OptionT<T>}
  */
 export function None() {
-    /**
-     *  @private
-     *  @type   {boolean}
-     */
-    this.ok = false;
-
-    /**
-     *  @private
-     *  @type   {T}
-     */
-    this.val = undefined;
-    Object.seal(this);
+    const o = new OptionBase(false, undefined);
+    Object.seal(o);
+    return o;
 }
-None.prototype = new OptionBase();
 
 /**
  *  @template   T

--- a/src/Option.js
+++ b/src/Option.js
@@ -46,6 +46,8 @@ export function OptionBase(ok, val) {
      *  @type   {T|undefined}
      */
     this.val = val;
+
+    Object.seal(this);
 }
 OptionBase.prototype = Object.freeze({
     /**
@@ -303,8 +305,7 @@ OptionBase.prototype = Object.freeze({
  *  @param  {T}   val
  */
 export function Some(val) {
-    const o = new OptionBase(true, val);
-    Object.seal(o);
+    const o = createSome(val);
     return o;
 }
 
@@ -317,8 +318,7 @@ export function Some(val) {
  *  @extends    {OptionBase<T>}
  */
 export function None() {
-    const o = new OptionBase(false, undefined);
-    Object.seal(o);
+    const o = createNone();
     return o;
 }
 
@@ -328,7 +328,7 @@ export function None() {
  *  @return    {OptionT<T>}
  */
 export function createSome(val) {
-    const o = new Some(val);
+    const o = new OptionBase(true, val);
     return o;
 }
 
@@ -337,6 +337,6 @@ export function createSome(val) {
  *  @return    {OptionT<T>}
  */
 export function createNone() {
-    const o = new None();
+    const o = new OptionBase(false, undefined);
     return o;
 }

--- a/src/Option.js
+++ b/src/Option.js
@@ -298,7 +298,7 @@ OptionBase.prototype = Object.freeze({
  *
  *  @constructor
  *  @template   T
- *  @extends    {OptionT<T>}
+ *  @extends    {OptionBase<T>}
  *
  *  @param  {T}   val
  */
@@ -314,7 +314,7 @@ export function Some(val) {
  *
  *  @constructor
  *  @template   T
- *  @extends    {OptionT<T>}
+ *  @extends    {OptionBase<T>}
  */
 export function None() {
     const o = new OptionBase(false, undefined);

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -174,7 +174,7 @@ interface Ok<T, E> extends ResultBase<T, E> {
  */
 interface OkConstructor {
     new<T, E>(v: T): Result<T, E>;
-    readonly prototype: Ok<any, any>; // tslint:disable-line:no-any
+    readonly prototype: ResultBase<any, any>; // tslint:disable-line:no-any
 }
 
 // XXX:
@@ -206,7 +206,7 @@ interface Err<T, E> extends ResultBase<T, E> {
  */
 interface ErrConstructor {
     new<T, E>(e: E): Result<T, E>;
-    readonly prototype: Err<any, any>; // tslint:disable-line:no-any
+    readonly prototype: ResultBase<any, any>; // tslint:disable-line:no-any
 }
 
 /**

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-import {Option, Some, None} from './Option';
+import { Option, Some, None } from './Option';
 import {
     MapFn,
     RecoveryWithErrorFn,
@@ -32,37 +32,30 @@ import {
 export type FlatmapOkFn<T, U, E> = MapFn<T, Result<U, E>>;
 export type FlatmapErrFn<T, E, F> = MapFn<E, Result<T, F>>;
 
-// XXX:
-// This is only used for the instanceof-basis runtime checking. (e.g. `React.PropTypes.instanceOf()`)
-// You MUST NOT use for other purpose.
-export abstract class ResultBase<T, E> {
-    private readonly _is_ok: boolean; // tslint:disable-line:variable-name
-    private readonly _v: T | undefined;
-    private readonly _e: E | undefined;
-
+interface Resultable<T, E> {
     /**
      *  Returns true if the result is `Ok`.
      */
-    abstract isOk(): this is Ok<T, E>;
+    isOk(): this is Ok<T, E>;
 
     /**
      *  Returns true if the result is `Err`.
      */
-    abstract isErr(): this is Err<T, E>;
+    isErr(): this is Err<T, E>;
 
     /**
      *  Converts from `Result<T, E>` to `Option<T>`.
      *  If the self is `Ok`, returns `Some<T>`.
      *  Otherwise, returns `None<T>`.
      */
-    abstract ok(): Option<T>;
+    ok(): Option<T>;
 
     /**
      *  Converts from `Result<T, E>` to `Option<E>`.
      *  If the self is `Err`, returns `Some<E>`.
      *  Otherwise, returns `None<E>`.
      */
-    abstract err(): Option<E>;
+    err(): Option<E>;
 
     /**
      *  Maps a `Result<T, E>` to `Result<U, E>` by applying a function `mapFn<T, U>`
@@ -70,7 +63,7 @@ export abstract class ResultBase<T, E> {
      *
      *  This function can be used to compose the results of two functions.
      */
-    abstract map<U>(op: MapFn<T, U>): Result<U, E>;
+    map<U>(op: MapFn<T, U>): Result<U, E>;
 
     /**
      *  Maps a `Result<T, E>` to `Result<T, F>` by applying a function `mapFn<E, F>`
@@ -78,29 +71,29 @@ export abstract class ResultBase<T, E> {
      *
      *  This function can be used to pass through a successful result while handling an error.
      */
-    abstract mapErr<F>(op: MapFn<E, F>): Result<T, F>;
+    mapErr<F>(op: MapFn<E, F>): Result<T, F>;
 
     /**
      *  Returns `res` if the result is `Ok`, otherwise returns the `Err` value of self.
      */
-    abstract and<U>(res: Result<U, E>): Result<U, E>;
+    and<U>(res: Result<U, E>): Result<U, E>;
 
     /**
      *  Calls `op` if the result is `Ok`, otherwise returns the `Err` value of self.
      *  This function can be used for control flow based on result values.
      */
-    abstract andThen<U>(op: FlatmapOkFn<T, U, E>): Result<U, E>;
+    andThen<U>(op: FlatmapOkFn<T, U, E>): Result<U, E>;
 
     /**
      *  Returns `res` if the result is `Err`, otherwise returns the `Ok` value of self.
      */
-    abstract or<F>(res: Result<T, F>): Result<T, F>;
+    or<F>(res: Result<T, F>): Result<T, F>;
 
     /**
      *  Calls `op` if the result is `Err`, otherwise returns the `Ok` value of self.
      *  This function can be used for control flow based on result values.
      */
-    abstract orElse<F>(op: FlatmapErrFn<T, E, F>): Result<T, F>;
+    orElse<F>(op: FlatmapErrFn<T, E, F>): Result<T, F>;
 
     /**
      *  Return the inner `T` of a `Ok(T)`.
@@ -108,7 +101,7 @@ export abstract class ResultBase<T, E> {
      *  @throws {Error}
      *      Throws if the self is a `Err`.
      */
-    abstract unwrap(): T | never;
+    unwrap(): T | never;
 
     /**
      *  Return the inner `E` of a `Err(E)`.
@@ -116,18 +109,18 @@ export abstract class ResultBase<T, E> {
      *  @throws {Error}
      *      Throws if the self is a `Ok`.
      */
-    abstract unwrapErr(): E | never;
+    unwrapErr(): E | never;
 
     /**
      *  Unwraps a result, return the content of an `Ok`. Else it returns `optb`.
      */
-    abstract unwrapOr(optb: T): T;
+    unwrapOr(optb: T): T;
 
     /**
      *  Unwraps a result, returns the content of an `Ok`.
      *  If the value is an `Err` then it calls `op` with its value.
      */
-    abstract unwrapOrElse(op: RecoveryWithErrorFn<E, T>): T;
+    unwrapOrElse(op: RecoveryWithErrorFn<E, T>): T;
 
     /**
      *  Return the inner `T` of a `Ok(T)`.
@@ -135,7 +128,7 @@ export abstract class ResultBase<T, E> {
      *  @throws {Error}
      *      Throws the passed `message` if the self is a `Err`.
      */
-    abstract expect(message: string): T | never;
+    expect(message: string): T | never;
 
     /**
      *  The destructor method inspired by Rust's `Drop` trait.
@@ -146,10 +139,19 @@ export abstract class ResultBase<T, E> {
      *  @param  errDestructor
      *      This would be called with the inner value if self is `Err<E>`.
      */
-    abstract drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
+    drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
-interface Ok<T, E> extends ResultBase<T, E> {
+// XXX:
+// This is only used for the instanceof-basis runtime checking. (e.g. `React.PropTypes.instanceOf()`)
+// You MUST NOT use for other purpose.
+export abstract class ResultBase<T, E> implements Resultable<T, E> {
+    private readonly _is_ok: boolean; // tslint:disable-line:variable-name
+    private readonly _v: T | undefined;
+    private readonly _e: E | undefined;
+
+    protected constructor(ok: boolean, val: T | undefined, err: E | undefined);
+
     isOk(): this is Ok<T, E>;
     isErr(): this is Err<T, E>;
     ok(): Option<T>;
@@ -160,12 +162,21 @@ interface Ok<T, E> extends ResultBase<T, E> {
     andThen<U>(op: FlatmapOkFn<T, U, E>): Result<U, E>;
     or<F>(res: Result<T, F>): Result<T, F>;
     orElse<F>(op: FlatmapErrFn<T, E, F>): Result<T, F>;
+    unwrap(): T | never;
+    unwrapErr(): E | never;
+    unwrapOr(optb: T): T;
+    unwrapOrElse(op: RecoveryWithErrorFn<E, T>): T;
+    expect(message: string): T | never;
+    drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
+}
+
+interface Ok<T, E> extends Resultable<T, E> {
+    ok(): Some<T>;
+    err(): None<E>;
     unwrap(): T;
     unwrapErr(): never;
     unwrapOr(optb: T): T;
-    unwrapOrElse(op: RecoveryWithErrorFn<E, T>): T;
     expect(message: string): T;
-    drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
 /**
@@ -173,7 +184,7 @@ interface Ok<T, E> extends ResultBase<T, E> {
  *  Instead, please use `createOk()`.
  */
 interface OkConstructor {
-    new<T, E>(v: T): Result<T, E>;
+    new <T, E>(v: T): Result<T, E>;
     readonly prototype: ResultBase<any, any>; // tslint:disable-line:no-any
 }
 
@@ -181,23 +192,12 @@ interface OkConstructor {
 // This class intend to represent the container of some error type `E`.
 // So we don't define this as `Error`'s subclass
 // or don't restrict type parameter `E`'s upper bound to `Error`.
-interface Err<T, E> extends ResultBase<T, E> {
-    isOk(): this is Ok<T, E>;
-    isErr(): this is Err<T, E>;
-    ok(): Option<T>;
-    err(): Option<E>;
-    map<U>(op: MapFn<T, U>): Result<U, E>;
-    mapErr<F>(op: MapFn<E, F>): Result<T, F>;
-    and<U>(res: Result<U, E>): Result<U, E>;
-    andThen<U>(op: FlatmapOkFn<T, U, E>): Result<U, E>;
-    or<F>(res: Result<T, F>): Result<T, F>;
-    orElse<F>(op: FlatmapErrFn<T, E, F>): Result<T, F>;
+interface Err<T, E> extends Resultable<T, E> {
+    ok(): None<T>;
+    err(): Some<E>;
     unwrap(): never;
     unwrapErr(): E;
-    unwrapOr(optb: T): T;
-    unwrapOrElse(op: RecoveryWithErrorFn<E, T>): T;
     expect(message: string): never;
-    drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
 /**
@@ -205,7 +205,7 @@ interface Err<T, E> extends ResultBase<T, E> {
  *  Instead, please use `createErr()`.
  */
 interface ErrConstructor {
-    new<T, E>(e: E): Result<T, E>;
+    new <T, E>(e: E): Result<T, E>;
     readonly prototype: ResultBase<any, any>; // tslint:disable-line:no-any
 }
 

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -146,7 +146,7 @@ interface Resultable<T, E> {
 // This is only used for the instanceof-basis runtime checking. (e.g. `React.PropTypes.instanceOf()`)
 // You MUST NOT use for other purpose.
 export abstract class ResultBase<T, E> implements Resultable<T, E> {
-    private readonly _is_ok: boolean; // tslint:disable-line:variable-name
+    private readonly _isOk: boolean; // tslint:disable-line:variable-name
     private readonly _v: T | undefined;
     private readonly _e: E | undefined;
 

--- a/src/Result.js
+++ b/src/Result.js
@@ -31,6 +31,8 @@ export function ResultBase(ok, val, err) {
      *  @type   {E}
      */
     this._e = err;
+
+    Object.seal(this);
 }
 ResultBase.prototype = Object.freeze({
 
@@ -322,8 +324,7 @@ ResultBase.prototype = Object.freeze({
  *  @param  {T} v
  */
 export function Ok(v) {
-    const r = new ResultBase(true, v, undefined);
-    Object.seal(r);
+    const r = createOk(v);
     return r;
 }
 
@@ -338,8 +339,7 @@ export function Ok(v) {
  *  @param  {E} e
  */
 export function Err(e) {
-    const r = new ResultBase(false, undefined, e);
-    Object.seal(r);
+    const r = createErr(e);
     return r;
 }
 
@@ -349,7 +349,7 @@ export function Err(e) {
  *  @return    {Result<T, E>}
  */
 export function createOk(v) {
-    const o = new Ok(v);
+    const o = new ResultBase(true, v, undefined);
     return o;
 }
 
@@ -359,6 +359,6 @@ export function createOk(v) {
  *  @return    {Result<T, E>}
  */
 export function createErr(e) {
-    const o = new Err(e);
+    const o = new ResultBase(false, undefined, e);
     return o;
 }

--- a/src/Result.js
+++ b/src/Result.js
@@ -14,13 +14,11 @@ import { Some, None } from './Option';
  *  The usecase example is a `React.PropTypes`.
  */
 export function ResultBase(ok, val, err) {
-    /* eslint-disable camelcase */
     /**
      *  @private
      *  @type   {boolean}
      */
-    this._is_ok = ok;
-    /* eslint-enable */
+    this._isOk = ok;
 
     /**
      *  @private
@@ -42,7 +40,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {boolean}
      */
     isOk: function ResultBaseIsOk() {
-        return this._is_ok;
+        return this._isOk;
     },
 
     /**
@@ -51,7 +49,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {boolean}
      */
     isErr: function ResultBaseIsErr() {
-        return !this._is_ok;
+        return !this._isOk;
     },
 
     /**
@@ -62,7 +60,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {!OptionT<T>}
      */
     ok: function ResultBaseOk() {
-        if (this._is_ok) {
+        if (this._isOk) {
             return new Some(this._v);
         }
         else {
@@ -78,7 +76,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {!OptionT<E>}
      */
     err: function ResultBaseErr() {
-        if (!this._is_ok) {
+        if (!this._isOk) {
             return new Some(this._e);
         }
         else {
@@ -97,7 +95,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {!Result<U, E>}
      */
     map: function ResultBaseMap(op) {
-        if (!this._is_ok) {
+        if (!this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
         }
@@ -118,7 +116,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {!Result<T, F>}
      */
     mapErr: function ResultBaseMapErr(op) {
-        if (this._is_ok) {
+        if (this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
         }
@@ -136,7 +134,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {!Result<U, E>}
      */
     and: function ResultBaseAnd(res) {
-        if (this._is_ok) {
+        if (this._isOk) {
             return res;
         }
         else {
@@ -154,7 +152,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {!Result<U, E>}
      */
     andThen: function ResultBaseAndThen(op) {
-        if (!this._is_ok) {
+        if (!this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
         }
@@ -176,7 +174,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {!Result<T, F>}
      */
     or: function ResultBaseOr(res) {
-        if (this._is_ok) {
+        if (this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
         }
@@ -194,7 +192,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {!Result<T, F>}
      */
     orElse: function ResultBaseOrElse(op) {
-        if (this._is_ok) {
+        if (this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
         }
@@ -229,7 +227,7 @@ ResultBase.prototype = Object.freeze({
      *      Throws if the self is a `Ok`.
      */
     unwrapErr: function ResultBaseUnwrapErr() {
-        if (this._is_ok) {
+        if (this._isOk) {
             throw new TypeError('called `unwrapErr()` on a `Ok` value');
         }
         else {
@@ -244,7 +242,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {T}
      */
     unwrapOr: function ResultBaseUnwrapOr(optb) {
-        if (this._is_ok) {
+        if (this._isOk) {
             return this._v;
         }
         else {
@@ -260,7 +258,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {T}
      */
     unwrapOrElse: function ResultBaseUnwrapOrElse(op) {
-        if (this._is_ok) {
+        if (this._isOk) {
             return this._v;
         }
 
@@ -278,7 +276,7 @@ ResultBase.prototype = Object.freeze({
      *      Throws the passed `message` if the self is a `Err`.
      */
     expect: function ResultBaseExpect(message) {
-        if (this._is_ok) {
+        if (this._isOk) {
             return this._v;
         }
         else {
@@ -297,7 +295,7 @@ ResultBase.prototype = Object.freeze({
      *  @return {void}
      */
     drop: function ResultBaseDrop(destructor, errDestructor) {
-        if (this._is_ok) {
+        if (this._isOk) {
             if (typeof destructor === 'function') {
                 destructor(this._v);
             }

--- a/src/Result.js
+++ b/src/Result.js
@@ -3,6 +3,9 @@ import { Some, None } from './Option';
 /**
  *  @constructor
  *  @template   T, E
+ *  @param  {boolean}   ok
+ *  @param  {T|undefined}   val
+ *  @param  {E|undefined}   err
  *
  *  A base object of `Result<T, E>`.
  *  This is only used to `option instanceof ResultBase`
@@ -10,7 +13,27 @@ import { Some, None } from './Option';
  *
  *  The usecase example is a `React.PropTypes`.
  */
-export function ResultBase() {}// eslint-disable-line no-empty-function
+export function ResultBase(ok, val, err) {
+    /* eslint-disable camelcase */
+    /**
+     *  @private
+     *  @type   {boolean}
+     */
+    this._is_ok = ok;
+    /* eslint-enable */
+
+    /**
+     *  @private
+     *  @type   {T}
+     */
+    this._v = val;
+
+    /**
+     *  @private
+     *  @type   {E}
+     */
+    this._e = err;
+}
 ResultBase.prototype = Object.freeze({
 
     /**
@@ -301,29 +324,10 @@ ResultBase.prototype = Object.freeze({
  *  @param  {T} v
  */
 export function Ok(v) {
-    /* eslint-disable camelcase */
-    /**
-     *  @private
-     *  @type   {boolean}
-     */
-    this._is_ok = true;
-    /* eslint-enable */
-
-    /**
-     *  @private
-     *  @type   {T}
-     */
-    this._v = v;
-
-    /**
-     *  @private
-     *  @type   {E}
-     */
-    this._e = undefined;
-
-    Object.seal(this);
+    const r = new ResultBase(true, v, undefined);
+    Object.seal(r);
+    return r;
 }
-Ok.prototype = new ResultBase();
 
 /**
  *  We're planning to deprecate this constructor (see https://github.com/karen-irc/option-t/issues/232).
@@ -336,29 +340,10 @@ Ok.prototype = new ResultBase();
  *  @param  {E} e
  */
 export function Err(e) {
-    /* eslint-disable camelcase */
-    /**
-     *  @private
-     *  @type   {boolean}
-     */
-    this._is_ok = false;
-    /* eslint-enable */
-
-    /**
-     *  @private
-     *  @type   {T}
-     */
-    this._v = undefined;
-
-    /**
-     *  @private
-     *  @type   {E}
-     */
-    this._e = e;
-
-    Object.seal(this);
+    const r = new ResultBase(false, undefined, e);
+    Object.seal(r);
+    return r;
 }
-Err.prototype = new ResultBase();
 
 /**
  *  @template   T, E

--- a/test/option-t/test_inheritance.js
+++ b/test/option-t/test_inheritance.js
@@ -11,12 +11,22 @@ describe('Inheritance for `Option<T>`', function(){
             const option = new Some(1);
             assert.strictEqual(option instanceof OptionBase, true);
         });
+
+        it('should not be instanceof `Some`', function() {
+            const option = new Some();
+            assert.strictEqual(option instanceof None, false);
+        });
     });
 
     describe('`None`', function () {
         it('should be instanceof `OptionBase`', function() {
             const option = new None();
             assert.strictEqual(option instanceof OptionBase, true);
+        });
+
+        it('should not be instanceof `None`', function() {
+            const option = new None();
+            assert.strictEqual(option instanceof None, false);
         });
     });
 });

--- a/test/result-te/test_inheritance.js
+++ b/test/result-te/test_inheritance.js
@@ -44,7 +44,7 @@ describe('Inheritance for `Result<T, E>`', function(){
         });
 
         it('should be instanceof `Ok`', function() {
-            assert.strictEqual(result instanceof Ok, true);
+            assert.strictEqual(result instanceof Ok, false);
         });
 
         it('should not be instanceof `Err`', function() {
@@ -64,7 +64,7 @@ describe('Inheritance for `Result<T, E>`', function(){
         });
 
         it('should be instanceof `Err`', function() {
-            assert.strictEqual(result instanceof ResultBase, true);
+            assert.strictEqual(result instanceof Err, false);
         });
 
         it('should not be instanceof `Ok`', function() {


### PR DESCRIPTION
## Detailed Breaking Changes

- Obsolete `instanceof` checking for `lib/Option` and `lib/Result`.
- Overhaul type definitions for `lib/Option` and `lib/Result`.
   - If your code use their type definitions, this may breaks your code.
- Rename `ResultBase._is_ok` to `ResultBase._isOk`.
   - These are private APIs. You should not use this.

## Related Issues

- Fix https://github.com/karen-irc/option-t/issues/232

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/287)
<!-- Reviewable:end -->
