### PR TITLE
Remove __ prefix from make's targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,34 +34,34 @@ help:
 # Clean
 ###########################
 .PHONY: clean
-clean: __clean_build __clean_test_cache __clean_type_test __clean_tmp_mjs
+clean: clean_build clean_test_cache clean_type_test clean_tmp_mjs
 
-.PHONY: __clean_build
-__clean_build: __clean_build_cjs __clean_build_esm __clean_build_mixedlib
+.PHONY: clean_build
+clean_build: clean_build_cjs clean_build_esm clean_build_mixedlib
 	$(NPM_BIN)/del $(TMP_MJS_DIR)
 
-.PHONY: __clean_build_cjs
-__clean_build_cjs:
+.PHONY: clean_build_cjs
+clean_build_cjs:
 	$(NPM_BIN)/del $(DIST_COMMONJS_DIR)
 
-.PHONY: __clean_build_esm
-__clean_build_esm:
+.PHONY: clean_build_esm
+clean_build_esm:
 	$(NPM_BIN)/del $(DIST_ESM_DIR)
 
-.PHONY: __clean_build_mixedlib
-__clean_build_mixedlib:
+.PHONY: clean_build_mixedlib
+clean_build_mixedlib:
 	$(NPM_BIN)/del $(DIST_MIXED_LIB_DIR)
 
-.PHONY: __clean_test_cache
-__clean_test_cache:
+.PHONY: clean_test_cache
+clean_test_cache:
 	$(NPM_BIN)/del $(TEST_CACHE_DIR)
 
-.PHONY: __clean_type_test
-__clean_type_test:
+.PHONY: clean_type_test
+clean_type_test:
 	$(NPM_BIN)/del $(TYPE_TEST_DIR)
 
 .PHONY: clean_tmp_mjs
-__clean_tmp_mjs:
+clean_tmp_mjs:
 	$(NPM_BIN)/del $(TMP_MJS_DIR)
 
 
@@ -72,76 +72,76 @@ __clean_tmp_mjs:
 build: build_cjs build_esm build_mixedlib ## Build all targets.
 
 .PHONY: build_cjs
-build_cjs: __build_cjs_js __build_cjs_type_definition __build_cjs_ts ## Build `cjs/`.
+build_cjs: build_cjs_js build_cjs_type_definition build_cjs_ts ## Build `cjs/`.
 
-.PHONY: __build_cjs_js
-__build_cjs_js: __clean_build_cjs
+.PHONY: build_cjs_js
+build_cjs_js: clean_build_cjs
 	$(NPM_BIN)/babel $(SRC_DIR) \
     --out-dir $(DIST_COMMONJS_DIR) \
     --extensions .js \
     --no-babelrc \
     --plugins transform-es2015-modules-commonjs,$(BABEL_PRD_TRANSFORMER_LIST)
 
-.PHONY: __build_cjs_type_definition
-__build_cjs_type_definition: __clean_build_cjs
+.PHONY: build_cjs_type_definition
+build_cjs_type_definition: clean_build_cjs
 	$(NPM_BIN)/cpx '$(SRC_DIR)/**/*.d.ts' $(DIST_COMMONJS_DIR) --preserve
 
-.PHONY: __build_cjs_ts
-__build_cjs_ts: __clean_build_cjs
+.PHONY: build_cjs_ts
+build_cjs_ts: clean_build_cjs
 	$(NPM_BIN)/tsc --project $(CURDIR)/tsconfig_cjs.json
 
 
 .PHONY: build_esm
-build_esm: __build_esm_js __build_esm_ts __build_mjs_cp_mjs_to_esm ## Build `esm/`.
+build_esm: build_esm_js build_esm_ts build_mjs_cp_mjs_to_esm ## Build `esm/`.
 
-.PHONY: __build_esm_js
-__build_esm_js: __build_esm_js_call_cpx __build_esm_js_call_babel
+.PHONY: build_esm_js
+build_esm_js: build_esm_js_call_cpx build_esm_js_call_babel
 
-.PHONY: __build_esm_js_call_cpx
-__build_esm_js_call_cpx: __clean_build_esm
+.PHONY: build_esm_js_call_cpx
+build_esm_js_call_cpx: clean_build_esm
 	$(NPM_BIN)/cpx '$(SRC_DIR)/**/*.d.ts' $(DIST_ESM_DIR) --preserve
 
-.PHONY: __build_esm_js_call_babel
-__build_esm_js_call_babel: __clean_build_esm
+.PHONY: build_esm_js_call_babel
+build_esm_js_call_babel: clean_build_esm
 	$(NPM_BIN)/babel $(SRC_DIR) --out-dir $(DIST_ESM_DIR) --extensions=.js --no-babelrc --plugins $(BABEL_PRD_TRANSFORMER_LIST)
 
-.PHONY: __build_esm_ts
-__build_esm_ts: __clean_build_esm
+.PHONY: build_esm_ts
+build_esm_ts: clean_build_esm
 	$(NPM_BIN)/tsc --project $(CURDIR)/tsconfig_esm.json
 
-.PHONY: __build_mjs_cp_mjs_to_esm
-__build_mjs_cp_mjs_to_esm: __build_mjs_rename_js_to_mjs
+.PHONY: build_mjs_cp_mjs_to_esm
+build_mjs_cp_mjs_to_esm: build_mjs_rename_js_to_mjs
 	$(NPM_BIN)/cpx '$(TMP_MJS_DIR)/**/*.mjs' $(DIST_ESM_DIR) --preserve
 
-.PHONY: __build_mjs_rename_js_to_mjs
-__build_mjs_rename_js_to_mjs: __build_mjs_create_tmp_mjs
+.PHONY: build_mjs_rename_js_to_mjs
+build_mjs_rename_js_to_mjs: build_mjs_create_tmp_mjs
 	$(NPM_BIN)/rename '$(TMP_MJS_DIR)/**/*.js' '{{f}}.mjs'
 
-.PHONY: __build_mjs_create_tmp_mjs
-__build_mjs_create_tmp_mjs: __build_mjs_create_tmp_mjs_call_tsc __build_mjs_create_tmp_mjs_call_babel
+.PHONY: build_mjs_create_tmp_mjs
+build_mjs_create_tmp_mjs: build_mjs_create_tmp_mjs_call_tsc build_mjs_create_tmp_mjs_call_babel
 
-.PHONY: __build_mjs_create_tmp_mjs_call_tsc
-__build_mjs_create_tmp_mjs_call_tsc: __clean_tmp_mjs
+.PHONY: build_mjs_create_tmp_mjs_call_tsc
+build_mjs_create_tmp_mjs_call_tsc: clean_tmp_mjs
 	$(NPM_BIN)/tsc --project $(CURDIR)/tsconfig_esm.json --outDir $(TMP_MJS_DIR) --declaration false
 
-.PHONY: __build_mjs_create_tmp_mjs_call_babel
-__build_mjs_create_tmp_mjs_call_babel: __clean_tmp_mjs
+.PHONY: build_mjs_create_tmp_mjs_call_babel
+build_mjs_create_tmp_mjs_call_babel: clean_tmp_mjs
 	$(NPM_BIN)/babel $(SRC_DIR) --out-dir $(TMP_MJS_DIR) --extensions=.js --no-babelrc --plugins $(BABEL_PRD_TRANSFORMER_LIST)
 
 
 .PHONY: build_mixedlib
-build_mixedlib: __build_mixedlib_cp_mjs __build_mixedlib_cp_cjs __build_mixedlib_cp_dts ## Build `lib/`.
+build_mixedlib: build_mixedlib_cp_mjs build_mixedlib_cp_cjs build_mixedlib_cp_dts ## Build `lib/`.
 
-.PHONY: __build_mixedlib_cp_mjs
-__build_mixedlib_cp_mjs: build_esm __clean_build_mixedlib
+.PHONY: build_mixedlib_cp_mjs
+build_mixedlib_cp_mjs: build_esm clean_build_mixedlib
 	$(NPM_BIN)/cpx '$(DIST_ESM_DIR)/**/*.mjs' $(DIST_MIXED_LIB_DIR) --preserve
 
-.PHONY: __build_mixedlib_cp_cjs
-__build_mixedlib_cp_cjs: build_cjs __clean_build_mixedlib
+.PHONY: build_mixedlib_cp_cjs
+build_mixedlib_cp_cjs: build_cjs clean_build_mixedlib
 	$(NPM_BIN)/cpx '$(DIST_COMMONJS_DIR)/**/*.js' $(DIST_MIXED_LIB_DIR) --preserve
 
-.PHONY: __build_mixedlib_cp_dts
-__build_mixedlib_cp_dts: build_esm __clean_build_mixedlib
+.PHONY: build_mixedlib_cp_dts
+build_mixedlib_cp_dts: build_esm clean_build_mixedlib
 	$(NPM_BIN)/cpx '$(DIST_ESM_DIR)/**/*.d.ts' $(DIST_MIXED_LIB_DIR) --preserve
 
 
@@ -149,14 +149,14 @@ __build_mixedlib_cp_dts: build_esm __clean_build_mixedlib
 # Lint
 ###########################
 .PHONY: lint
-lint: __eslint __tslint ## Run all lints
+lint: eslint tslint ## Run all lints
 
-.PHONY: __eslint
-__eslint:
+.PHONY: eslint
+eslint:
 	$(NPM_BIN)/eslint $(CURDIR) '$(CURDIR)/**/.eslintrc.js' --ext=.js,.jsx,.mjs
 
-.PHONY: __tslint
-__tslint:
+.PHONY: tslint
+tslint:
 	$(NPM_BIN)/tslint --config $(CURDIR)/tslint.json '$(CURDIR)/src/**/*.ts{,x}'
 
 
@@ -164,33 +164,32 @@ __tslint:
 # Test
 ###########################
 .PHONY: test
-test: lint build __mocha tscheck ## Run all tests
-
-
-
-.PHONY: git_diff
-git_diff: ## Test whether there is no committed changes.
-	git diff --exit-code
+test: lint build mocha tscheck ## Run all tests
 
 .PHONY: tscheck
-tscheck: __clean_type_test build ## Test check typing consistency.
+tscheck: clean_type_test build ## Test check typing consistency.
 	$(NPM_BIN)/tsc --project $(CURDIR)/tsconfig_test.json --noEmit
 
-.PHONY: __test_preprocess
-__test_preprocess: __clean_test_cache
+.PHONY: test_preprocess
+test_preprocess: clean_test_cache
 	$(NPM_BIN)/babel $(SRC_TEST_DIR) --out-dir $(TEST_CACHE_DIR) --extensions .js --presets power-assert
 
-.PHONY: __mocha
-__mocha: __test_preprocess build
-	$(MAKE) __run_mocha_with_power_assert -C $(CURDIR)
+.PHONY: mocha
+mocha: test_preprocess build
+	$(MAKE) run_mocha_with_power_assert -C $(CURDIR)
 
-.PHONY: __run_mocha_with_power_assert
-__run_mocha_with_power_assert:
+.PHONY: run_mocha_with_power_assert
+run_mocha_with_power_assert:
 	$(NPM_BIN)/mocha --recursive '$(TEST_CACHE_DIR)/**/test_*.js' --reporter $(MOCHA_REPORTER)
 
 .PHONY: run_mocha
 run_mocha: ## Run mocha without any transforms.
 	$(NPM_BIN)/mocha --recursive '$(SRC_TEST_DIR)/**/test_*.js' --reporter $(MOCHA_REPORTER)
+
+
+.PHONY: git_diff
+git_diff: ## Test whether there is no committed changes.
+	git diff --exit-code
 
 
 ###########################
@@ -206,14 +205,14 @@ ci:
 # Tools
 ###########################
 .PHONY: fmt
-fmt: __eslint_fmt __tslint_fmt ## Apply all formatters
+fmt: eslint_fmt tslint_fmt ## Apply all formatters
 
-.PHONY: __eslint_fmt
-__eslint_fmt: 
+.PHONY: eslint_fmt
+eslint_fmt: 
 	$(NPM_BIN)/eslint $(CURDIR) $(CURDIR)/**/.eslintrc.js --ext .js --fix
 
-.PHONY: __tslint_fmt
-__tslint_fmt: 
+.PHONY: tslint_fmt
+tslint_fmt: 
 	$(NPM_BIN)/tslint --config $(CURDIR)/tslint.json '$(CURDIR)/src/**/*.ts{,x}'
 
 .PHONY: prepublish


### PR DESCRIPTION
* If we add `__` prefix to each of targets, they will not shown in
  tab-completion in bash with autocomplete script.
  * We can mark a public targets with a magic comment which helps by
  `make help`.
* We should use `__` to a target which have some states and you cannot
  call it from outer script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/301)
<!-- Reviewable:end -->
