### PR TITLE
Remove unnecessary 'src' field from tesconfig_*.json

### DIFF
--- a/tsconfig_cjs.json
+++ b/tsconfig_cjs.json
@@ -6,11 +6,6 @@
         "noEmitOnError": true,
         "outDir": "./cjs/"
     },
-    "src": [
-        "./src/Maybe/index.ts",
-        "./src/Nullable/index.ts",
-        "./src/Undefinable/index.ts"
-    ],
     "exclude": [
         "test"
     ]

--- a/tsconfig_esm.json
+++ b/tsconfig_esm.json
@@ -6,11 +6,6 @@
         "noEmitOnError": true,
         "outDir": "./esm/"
     },
-    "src": [
-        "./src/Maybe/index.ts",
-        "./src/Nullable/index.ts",
-        "./src/Undefinable/index.ts"
-    ],
     "exclude": [
         "test"
     ]


### PR DESCRIPTION
* We ensure the build result with `make test` which depends on `make build`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/315)
<!-- Reviewable:end -->
