### PR TITLE
Specify yarnpkg version explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ node_js:
   - "10"
   - "node" # latest stable Node.js release
 
+env:
+  - YARNPKG_VERSION=1.10.1
+
 branches:
   except:
     # These branches are used by bors-ng
@@ -18,8 +21,8 @@ notifications:
   email: false
 
 before_install:
-  # Use the latest yarnpkg because Travis' builtin yarn is not the latest.
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  # Use the yarnpkg installed by self because Travis' builtin yarn is not the latest.
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARNPKG_VERSION}
   - export PATH=$HOME/.yarn/bin:$PATH
   - which yarn # for debugging Travis
   - echo $PATH # for debugging Travis


### PR DESCRIPTION
This avoid the failure by changing yarn.lock format by yarnpkg change.

## Drawbacks

By this change, we need to specify the version of yarnpkg.
It increases our maintenance burden.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/318)
<!-- Reviewable:end -->
