### PR TITLE
Relax `this` type for callback functions

### DIFF
--- a/src/shared/Function.ts
+++ b/src/shared/Function.ts
@@ -1,4 +1,4 @@
-export type MapFn<T, U> = (this: void, v: T) => U;
-export type RecoveryFn<T> = (this: void) => T;
-export type RecoveryWithErrorFn<E, T> = (this: void, e: E) => T;
-export type TapFn<T> = (this: void, v: T) => void;
+export type MapFn<T, U> = (v: T) => U;
+export type RecoveryFn<T> = () => T;
+export type RecoveryWithErrorFn<E, T> = (e: E) => T;
+export type TapFn<T> = (v: T) => void;


### PR DESCRIPTION
By [TypeScript 3.2](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html)'s `strictBindCallApply` option, the below code would be a compile error.

```typescript
const fn: (this: number, input: number) => string => function (a) {
  return String(a);
}.bind(1);

const input: Nullable<number> = 1;

// compile error: `fn` type is mispatched with `(this: void, v: T) =>U`.
const r: Nullable<number> = mapForNullable(input, fn);
```

I think this might be one of rare cases.
But I also think we should relax the type of `this` for callback functions.

By this change, we remove `this: void` from all callback functions' type. This allow the above sample code.

You can seem this change will introduces a new pitfall like this:

```typescript
mapForNullable(input, function (v) {
  return this.bar(v);
});
```

However, I don't think this would be a new pitfall because:

1. typescipt compiler (at least 3.2)  make it error as that _'this' implicitly has type 'any' because it does not have a type annotation. [2683]_.
2. tslint have some rules which checks to use `this` like this kind.
    - `no-invalid-this`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/322)
<!-- Reviewable:end -->
