### PR TITLE
Implement mapOrElseForResult<T, E, U>

### DIFF
--- a/ava_test/PlainResult/test_map_or_else.js
+++ b/ava_test/PlainResult/test_map_or_else.js
@@ -1,0 +1,46 @@
+import test from 'ava';
+
+const {
+    createOk,
+    createErr,
+} = require('../../cjs/PlainResult/Result');
+
+const {
+    mapOrElseForResult
+} = require('../../cjs/PlainResult/mapOrElse');
+
+const PLAN_COUNT = 2;
+
+test('Ok<T>', (t) => {
+    const INITIAL = 1;
+    const EXPECTED = 3;
+
+    t.plan(PLAN_COUNT);
+
+    const input = createOk(INITIAL);
+    const r = mapOrElseForResult(input, (_e) => {
+        t.fail(`don't enter this path`);
+    }, (v) => {
+        t.is(v, INITIAL, 'the argument');
+        return EXPECTED;
+    });
+
+    t.is(r, 3, 'the return value');
+});
+
+test('Err<E>', (t) => {
+    const INITIAL = 1;
+    const EXPECTED = 3;
+
+    t.plan(PLAN_COUNT);
+
+    const input = createErr(INITIAL);
+    const r = mapOrElseForResult(input, (e) => {
+        t.is(e, INITIAL, 'the argument');
+        return EXPECTED;
+    }, (_v) => {
+        t.fail(`don't enter this path`);
+    });
+
+    t.is(r, 3, 'the return value');
+});

--- a/ava_test/Result/test_map_or_else.js
+++ b/ava_test/Result/test_map_or_else.js
@@ -1,0 +1,42 @@
+import test from 'ava';
+
+const {
+    createOk,
+    createErr,
+} = require('../../cjs/Result');
+
+const PLAN_COUNT = 2;
+
+test('Ok<T>', (t) => {
+    const INITIAL = 1;
+    const EXPECTED = 3;
+
+    t.plan(PLAN_COUNT);
+
+    const input = createOk(INITIAL);
+    const r = input.mapOrElse((_e) => {
+        t.fail(`don't enter this path`);
+    }, (v) => {
+        t.is(v, INITIAL, 'the argument');
+        return EXPECTED;
+    });
+
+    t.is(r, 3, 'the return value');
+});
+
+test('Err<E>', (t) => {
+    const INITIAL = 1;
+    const EXPECTED = 3;
+
+    t.plan(PLAN_COUNT);
+
+    const input = createErr(INITIAL);
+    const r = input.mapOrElse((e) => {
+        t.is(e, INITIAL, 'the argument');
+        return EXPECTED;
+    }, (_v) => {
+        t.fail(`don't enter this path`);
+    });
+
+    t.is(r, 3, 'the return value');
+});

--- a/src/PlainResult/index.ts
+++ b/src/PlainResult/index.ts
@@ -18,6 +18,7 @@ export {
     expectIsErr as expectErr,
  } from './expect';
 export { mapForResult as map } from './map';
+export { mapOrElseForResult as mapOrElse } from './mapOrElse';
 export { mapErrForResult as mapErr } from './mapErr';
 export { orForResult as or } from './or';
 export { orElseForResult as orElse } from './orElse';

--- a/src/PlainResult/mapOrElse.ts
+++ b/src/PlainResult/mapOrElse.ts
@@ -1,0 +1,13 @@
+import { MapFn, RecoveryWithErrorFn } from '../shared/Function';
+import { Result } from './Result';
+
+export function mapOrElseForResult<T, E, U>(src: Result<T, E>, fallback: RecoveryWithErrorFn<E, U>, selector: MapFn<T, U>): U {
+    if (src.ok) {
+        const r: U = selector(src.val);
+        return r;
+    }
+    else {
+        const r: U = fallback(src.err);
+        return r;
+    }
+}

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -66,6 +66,13 @@ interface Resultable<T, E> {
     map<U>(op: MapFn<T, U>): Result<U, E>;
 
     /**
+     *  Maps a `Result<T, E>` to `U` by applying a function to a contained `Ok` value,
+     *  or a `fallback` function to a contained `Err` value.
+     *  This function can be used to unpack a successful result while handling an error.
+     */
+    mapOrElse<U>(fallback: RecoveryWithErrorFn<E, U>, selector: MapFn<T, U>): U;
+
+    /**
      *  Maps a `Result<T, E>` to `Result<T, F>` by applying a function `mapFn<E, F>`
      *  to an contained `Err` value, leaving an `Ok` value untouched.
      *
@@ -157,6 +164,7 @@ export abstract class ResultBase<T, E> implements Resultable<T, E> {
     ok(): Option<T>;
     err(): Option<E>;
     map<U>(op: MapFn<T, U>): Result<U, E>;
+    mapOrElse<U>(fallback: RecoveryWithErrorFn<E, U>, selector: MapFn<T, U>): U;
     mapErr<F>(op: MapFn<E, F>): Result<T, F>;
     and<U>(res: Result<U, E>): Result<U, E>;
     andThen<U>(op: FlatmapOkFn<T, U, E>): Result<U, E>;

--- a/src/Result.js
+++ b/src/Result.js
@@ -108,6 +108,26 @@ ResultBase.prototype = Object.freeze({
     },
 
     /**
+     *  Maps a `Result<T, E>` to `U` by applying a function to a contained `Ok` value,
+     *  or a `fallback` function to a contained `Err` value.
+     *  This function can be used to unpack a successful result while handling an error.
+     *
+     *  @template   U
+     *  @param  {!function(E):U}    fallback
+     *  @param  {!function(T):U}    selector
+     *  @return {U}
+     */
+    mapOrElse: function ResultBaseMapOrResult(fallback, selector) {
+        if (!this._isOk) {
+            const r = fallback(this._e);
+            return r;
+        }
+
+        const r = selector(this._v);
+        return r;
+    },
+
+    /**
      *  Maps a `Result<T, E>` to `Result<T, F>` by applying a function `mapFn<E, F>`
      *  to an contained `Err` value, leaving an `Ok` value untouched.
      *


### PR DESCRIPTION
This API is still experimental in rust.
https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else

But I think this is useful and it's easy to make this compatible
for the future breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/327)
<!-- Reviewable:end -->
