### PR TITLE
Add the guide to no recommendation to use wrapper objects in almost case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 
 ## x.y.z
 
+### Documentations
+
+#### Add the guide to no recommendation to use _wrapper objects (`optiont-/{cjs,esm,lib}/Option<T>` & `optiont-/{cjs,esm,lib}/Result<T, E>`)_ in almost case.
+([#337](https://github.com/karen-irc/option-t/pull/337))
+
+* Basically, we recommend to use _utility types & functions_.
+* _Wrapper objects_ has some downside if your project has multiple versions of this package in its project dependencies.
+    * `instanceof` might not work expectedly if you `(a instanceof b)` in this case.
+      This is confusable behavior.
+        * `a` is created by the constructor provided by the version _a_ of this.
+        * `b` is the constructor provided by the version _b_ of this.
+    * Broat bundle size unnecessarily.
+        * It's hard for almost JS code minifier to minify a property on prototype chain.
+* So we decide to no-recommend _wrapper objects_ without any strong motivation.
+    * This does not mean to make them obsolete or deprecate **now**.
+    * We don't have any concrete plan to deperecate these API.
+    * Of course, however, we would lower priorities of them.
+
 
 ## 18.1.2
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ yarn add option-t --save
 
 These are designed for more tree shaking friendly and more usable for JavaScript common world.
 
+_We recommend to use these in almost case._
+
 #### [`Nullable<T>` (`T | null`)](./src/Nullable/)
 
 This can express a value of `T` type or `null`.
@@ -153,6 +155,12 @@ This does not have any property method on its prototype. But this allows no incl
 ### Wrapper objects
 
 This is a wrapper object which have utility methods on its prototype.
+
+_We recommend to use utility types & functions if you don't have to use `instanceof` check and
+you should avoid to expose this object as a public API of your package_ 
+because `instanceof` checking might not work correctly if a user project has multiple version of this package in their dependencies.
+See ([#337](https://github.com/karen-irc/option-t/pull/337)).
+
 
 #### [`Option<T>`](./src/Option.d.ts)
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,6 @@ yarn add option-t --save
 
 ## Usage & APIs
 
-* Wrapper objects
-    * [`Option<T>`](./src/Option.d.ts)
-    * [`Result<T, E>`](./src/Result.d.ts)
 * Utility functions for these types (TypeScript ready).
     * [`Nullable<T>` (`T | null`)](./src/Nullable/)
     * [`Undefinable<T>` (`T | undefined`)](./src/Undefinable/)
@@ -121,6 +118,36 @@ yarn add option-t --save
     * plain objects
         * [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./src/PlainOption/)
         * [`Result<T, E>` (`{ ok: true; val: T } | { ok: false; err: E; }`)](./src/PlainResult/)
+* Wrapper objects
+    * [`Option<T>`](./src/Option.d.ts)
+    * [`Result<T, E>`](./src/Result.d.ts)
+
+
+### Utility functions for some types.
+
+These are designed for more tree shaking friendly and more usable for JavaScript common world.
+
+#### [`Nullable<T>` (`T | null`)](./src/Nullable/)
+
+This can express a value of `T` type or `null`.
+
+#### [`Undefinable<T>` (`T | undefined`)](./src/Undefinable/)
+
+This can express a value of `T` type or `undefined`.
+
+#### [`Maybe<T>` (`T | null | undefined`)](./src/Maybe/)
+
+This can express a value of `T` type, `null`, or `undefined`.
+
+####  [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./src/PlainOption/)
+
+This can express that there is some values or none _as a plain object_.
+This does not have any property method on its prototype. But this allows no including unused methods of them.
+
+#### [`Result<T, E>` (`{ ok: true; val: T } | { ok: false; err: E; }`)](./src/PlainResult/)
+
+This can express that there is some values or some error information _as a plain object_.
+This does not have any property method on its prototype. But this allows no including unused methods of them.
 
 
 ### Wrapper objects
@@ -168,33 +195,6 @@ console.log(none.isOk()); // false
 console.log(none.unwrap()); // this will throw `Error`.
 console.log(none.unwrapErr()); // 'some error info'
 ```
-
-
-### Utility functions for some types.
-
-These are designed for more tree shaking friendly and more usable for JavaScript common world.
-
-#### [`Nullable<T>` (`T | null`)](./src/Nullable/)
-
-This can express a value of `T` type or `null`.
-
-#### [`Undefinable<T>` (`T | undefined`)](./src/Undefinable/)
-
-This can express a value of `T` type or `undefined`.
-
-#### [`Maybe<T>` (`T | null | undefined`)](./src/Maybe/)
-
-This can express a value of `T` type, `null`, or `undefined`.
-
-####  [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./src/PlainOption/)
-
-This can express that there is some values or none _as a plain object_.
-This does not have any property method on its prototype. But this allows no including unused methods of them.
-
-#### [`Result<T, E>` (`{ ok: true; val: T } | { ok: false; err: E; }`)](./src/PlainResult/)
-
-This can express that there is some values or some error information _as a plain object_.
-This does not have any property method on its prototype. But this allows no including unused methods of them.
 
 
 ### How to import


### PR DESCRIPTION
* Basically, we recommend to use _utility types & functions_.
* _Wrapper objects_ has some downside if your project has multiple versions of this package in its project dependencies.
    * `instanceof` might work unexpectedly if you `(a instanceof b)` in this case.
      This is confusable behavior.
        * `a` is created by the constructor provided by the version _a_ of this.
        * `b` is the constructor provided by the version _b_ of this.
    * Bloat bundle size unnecessarily.
        * It's hard for almost JS code minifier to minify a property on prototype chain.
* So we decide to no-recommend _wrapper objects_ without any strong motivation.
    * This does not means to make them obsolete or deprecate **now**.
    * We don't have any concrete plan to deprecate these API.
    * Of course, however, we would lower priorities of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/337)
<!-- Reviewable:end -->
