### PR TITLE
Drop Node.js v8 from out CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 language: node_js
 
 node_js:
-  - "8"
   - "10"
   - "node" # latest stable Node.js release
 


### PR DESCRIPTION
This does not mean that this code will not run with Node.js v8 immediately.
But this allow to introduce a change which is incompatible with Node v8

Fix https://github.com/karen-irc/option-t/issues/324

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/338)
<!-- Reviewable:end -->
