### PR TITLE
Add _non nullable_ types by conditional types

### DIFF
--- a/src/Maybe/Maybe.ts
+++ b/src/Maybe/Maybe.ts
@@ -1,3 +1,5 @@
+export type NotNullAndUndefined<T> = T extends (null | undefined) ? never : T;
+
 export type Maybe<T> = T | null | undefined;
 
 export function isNotNullAndUndefined<T>(v: Maybe<T>): v is T {

--- a/src/Nullable/Nullable.ts
+++ b/src/Nullable/Nullable.ts
@@ -1,3 +1,5 @@
+export type NotNull<T> = T extends null ? never : T;
+
 export type Nullable<T> = T | null;
 
 export function isNotNull<T>(v: Nullable<T>): v is T {

--- a/src/Undefinable/Undefinable.ts
+++ b/src/Undefinable/Undefinable.ts
@@ -1,3 +1,5 @@
+export type NotUndefined<T> = T extends undefined ? never : T;
+
 export type Undefinable<T> = T | undefined;
 
 export function isNotUndefined<T>(v: Undefinable<T>): v is T {


### PR DESCRIPTION
TypeScript compiler has builtin
`NonNullable<T> = T extends null | undefined ? never : T`.

So I named `Not***` for introduced types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/344)
<!-- Reviewable:end -->
