### PR TITLE
Mark as "non nullable" for  type signatures of Nullable/Undefinable/Maybe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "option-t",
-  "version": "v20.0.0-alpha.1",
+  "version": "v20.0.0-alpha.2",
   "description": "Option type implementation whose APIs are inspired by Rust's `Option<T>`.",
   "main": "cjs/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "option-t",
-  "version": "v20.0.0-alpha.3",
+  "version": "v20.0.0-alpha.4",
   "description": "Option type implementation whose APIs are inspired by Rust's `Option<T>`.",
   "main": "cjs/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "option-t",
-  "version": "19.1.0",
+  "version": "v20.0.0-alpha.1",
   "description": "Option type implementation whose APIs are inspired by Rust's `Option<T>`.",
   "main": "cjs/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "option-t",
-  "version": "v20.0.0-alpha.2",
+  "version": "v20.0.0-alpha.3",
   "description": "Option type implementation whose APIs are inspired by Rust's `Option<T>`.",
   "main": "cjs/index.js",
   "files": [

--- a/src/Maybe/Maybe.ts
+++ b/src/Maybe/Maybe.ts
@@ -1,5 +1,22 @@
 export type NotNullAndUndefined<T> = T extends (null | undefined) ? never : T;
 
+// XXX:
+// If we define `type Maybe<T> = NotNullAndUndefined<T> | null`,
+// the following case would be compile error.
+//
+// ``` typescript
+//  function bar<T>(input: T): Maybe<T> {
+//      if (Math.random() > 0.5) {
+//          return input; // <- compile error.
+//          // Type 'T' is not assignable to type 'Maybe<T>'.
+//          // Type 'T' is not assignable to type 'NotNullAndUndefined<T>'.ts(2322)
+//      }
+//      return null;
+//  }
+//  ```
+//
+// This is less ergonomic with generics.
+// So we don't define this as `NotNullAndUndefined<T> | null`.
 export type Maybe<T> = T | null | undefined;
 
 export function isNotNullAndUndefined<T>(v: Maybe<T>): v is NotNullAndUndefined<T> {

--- a/src/Maybe/Maybe.ts
+++ b/src/Maybe/Maybe.ts
@@ -2,7 +2,7 @@ export type NotNullAndUndefined<T> = T extends (null | undefined) ? never : T;
 
 export type Maybe<T> = T | null | undefined;
 
-export function isNotNullAndUndefined<T>(v: Maybe<T>): v is T {
+export function isNotNullAndUndefined<T>(v: Maybe<T>): v is NotNullAndUndefined<T> {
     return v !== undefined && v !== null;
 }
 

--- a/src/Maybe/expect.ts
+++ b/src/Maybe/expect.ts
@@ -1,13 +1,13 @@
-import { Maybe } from './Maybe';
+import { Maybe, NotNullAndUndefined, isNotNullAndUndefined } from './Maybe';
 
 /**
  *  Return _v_ as `T` if the passed _v_ is not `null` and `undefined`.
  *  Otherwise, throw `TypeError` with the passed `msg`.
  */
-export function expectNotNullAndUndefined<T>(v: Maybe<T>, msg: string): T | never {
-    if (v === undefined || v === null) {
-        throw new TypeError(msg);
+export function expectNotNullAndUndefined<T>(v: Maybe<T>, msg: string): NotNullAndUndefined<T> {
+    if (isNotNullAndUndefined(v)) {
+        return v;
     }
 
-    return v;
+    throw new TypeError(msg);
 }

--- a/src/Maybe/map.ts
+++ b/src/Maybe/map.ts
@@ -1,7 +1,7 @@
 import { expectNotNullAndUndefined } from './expect';
 import { ERR_MSG_SELECTOR_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE } from './ErrorMessage';
 import { MapFn } from '../shared/Function';
-import { Maybe } from './Maybe';
+import { Maybe, NotNullAndUndefined } from './Maybe';
 
 /**
  *  Return the result of _selector_ with using _src_ as an argument for it if _src_ is not `null` and `undefined`.
@@ -11,7 +11,7 @@ import { Maybe } from './Maybe';
  *      * If you'd like return `Maybe<*>` as `U`, use `andThen()`.
  *      * If the result of _selector_ is `null` or `undefined`, this throw an `Error`.
  */
-export function mapForMaybe<T, U>(src: Maybe<T>, selector: MapFn<T, U>): Maybe<U> {
+export function mapForMaybe<T, U>(src: Maybe<T>, selector: MapFn<T, NotNullAndUndefined<U>>): Maybe<U> {
     if (src !== undefined && src !== null) {
         const r: U = selector(src);
         // XXX:

--- a/src/Maybe/mapOr.ts
+++ b/src/Maybe/mapOr.ts
@@ -14,7 +14,7 @@ import { MapFn } from '../shared/Function';
  *      * If the result of _def_ is `null` or `undefined`, this throw an `Error`.
  *  * If you'd like to accept `Maybe<*>` as `U`, use a combination `andThen()` and `or()`.
  */
-export function mapOrForMaybe<T, U>(src: Maybe<T>, def: U, selector: MapFn<T, U>): NotNullAndUndefined<U> {
+export function mapOrForMaybe<T, U>(src: Maybe<T>, def: NotNullAndUndefined<U>, selector: MapFn<T, NotNullAndUndefined<U>>): NotNullAndUndefined<U> {
     let r: U;
     let msg = '';
     if (src !== undefined && src !== null) {

--- a/src/Maybe/mapOr.ts
+++ b/src/Maybe/mapOr.ts
@@ -1,4 +1,4 @@
-import { Maybe } from './Maybe';
+import { Maybe, NotNullAndUndefined } from './Maybe';
 import { expectNotNullAndUndefined } from './expect';
 import { ERR_MSG_SELECTOR_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE, ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_MAYBE } from './ErrorMessage';
 import { MapFn } from '../shared/Function';
@@ -14,7 +14,7 @@ import { MapFn } from '../shared/Function';
  *      * If the result of _def_ is `null` or `undefined`, this throw an `Error`.
  *  * If you'd like to accept `Maybe<*>` as `U`, use a combination `andThen()` and `or()`.
  */
-export function mapOrForMaybe<T, U>(src: Maybe<T>, def: U, selector: MapFn<T, U>): U {
+export function mapOrForMaybe<T, U>(src: Maybe<T>, def: U, selector: MapFn<T, U>): NotNullAndUndefined<U> {
     let r: U;
     let msg = '';
     if (src !== undefined && src !== null) {

--- a/src/Maybe/mapOrElse.ts
+++ b/src/Maybe/mapOrElse.ts
@@ -17,7 +17,7 @@ import { Maybe, NotNullAndUndefined } from './Maybe';
  *      * If the result of _def_ is `null` or `undefined`, this throw an `Error`.
  *  * If you'd like to accept `Maybe<*>` as `U`, use a combination `andThen()` and `orElse()`.
  */
-export function mapOrElseForMaybe<T, U>(src: Maybe<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): NotNullAndUndefined<U> {
+export function mapOrElseForMaybe<T, U>(src: Maybe<T>, def: RecoveryFn<NotNullAndUndefined<U>>, selector: MapFn<T, NotNullAndUndefined<U>>): NotNullAndUndefined<U> {
     let r: U;
     let msg = '';
     if (src !== undefined && src !== null) {

--- a/src/Maybe/mapOrElse.ts
+++ b/src/Maybe/mapOrElse.ts
@@ -4,7 +4,7 @@ import {
     ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE,
 } from './ErrorMessage';
 import { MapFn, RecoveryFn } from '../shared/Function';
-import { Maybe } from './Maybe';
+import { Maybe, NotNullAndUndefined } from './Maybe';
 
 /**
  *  Return the result of _selector_ with using _src_ as an argument for it if _src_ is not `null` and `undefined`.
@@ -17,7 +17,7 @@ import { Maybe } from './Maybe';
  *      * If the result of _def_ is `null` or `undefined`, this throw an `Error`.
  *  * If you'd like to accept `Maybe<*>` as `U`, use a combination `andThen()` and `orElse()`.
  */
-export function mapOrElseForMaybe<T, U>(src: Maybe<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): U {
+export function mapOrElseForMaybe<T, U>(src: Maybe<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): NotNullAndUndefined<U> {
     let r: U;
     let msg = '';
     if (src !== undefined && src !== null) {

--- a/src/Maybe/unwrap.ts
+++ b/src/Maybe/unwrap.ts
@@ -1,11 +1,11 @@
 import { expectNotNullAndUndefined } from './expect';
-import { Maybe } from './Maybe';
+import { Maybe, NotNullAndUndefined } from './Maybe';
 import { ERR_MSG_UNWRAP_NO_VAL_FOR_MAYBE } from './ErrorMessage';
 
 /**
  *  Return _v_ as `T` if the passed _v_ is not `null` and `undefined`.
  *  Otherwise, throw `TypeError`.
  */
-export function unwrapMaybe<T>(v: Maybe<T>): T | never {
+export function unwrapMaybe<T>(v: Maybe<T>): NotNullAndUndefined<T> {
     return expectNotNullAndUndefined(v, ERR_MSG_UNWRAP_NO_VAL_FOR_MAYBE);
 }

--- a/src/Maybe/unwrapOr.ts
+++ b/src/Maybe/unwrapOr.ts
@@ -1,4 +1,4 @@
-import { Maybe } from './Maybe';
+import { Maybe, NotNullAndUndefined, isNotNullAndUndefined } from './Maybe';
 import { expectNotNullAndUndefined } from './expect';
 import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_MAYBE } from './ErrorMessage';
 
@@ -9,8 +9,8 @@ import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_MAYBE } from './ErrorMessage';
  *  * _def_ must not be `Maybe<*>`.
  *  * If the _def_ is `null` or `undefined`, throw `TypeError`.
  */
-export function unwrapOrFromMaybe<T>(v: Maybe<T>, def: T): T {
-    if (v !== undefined && v !== null) {
+export function unwrapOrFromMaybe<T>(v: Maybe<T>, def: T): NotNullAndUndefined<T> {
+    if (isNotNullAndUndefined(v)) {
         return v;
     }
     else {

--- a/src/Maybe/unwrapOr.ts
+++ b/src/Maybe/unwrapOr.ts
@@ -9,7 +9,7 @@ import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_MAYBE } from './ErrorMessage';
  *  * _def_ must not be `Maybe<*>`.
  *  * If the _def_ is `null` or `undefined`, throw `TypeError`.
  */
-export function unwrapOrFromMaybe<T>(v: Maybe<T>, def: T): NotNullAndUndefined<T> {
+export function unwrapOrFromMaybe<T>(v: Maybe<T>, def: NotNullAndUndefined<T>): NotNullAndUndefined<T> {
     if (isNotNullAndUndefined(v)) {
         return v;
     }

--- a/src/Maybe/unwrapOrElse.ts
+++ b/src/Maybe/unwrapOrElse.ts
@@ -10,7 +10,7 @@ import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE } from './ErrorMessage';
  *  * The result of _def_ must not be `Maybe<*>`.
  *  * If the result of _def_ is `null` or `undefined`, throw `TypeError`.
  */
-export function unwrapOrElseFromMaybe<T>(v: Maybe<T>, def: RecoveryFn<T>): NotNullAndUndefined<T> {
+export function unwrapOrElseFromMaybe<T>(v: Maybe<T>, def: RecoveryFn<NotNullAndUndefined<T>>): NotNullAndUndefined<T> {
     if (isNotNullAndUndefined(v)) {
         return v;
     }

--- a/src/Maybe/unwrapOrElse.ts
+++ b/src/Maybe/unwrapOrElse.ts
@@ -1,5 +1,5 @@
 import { RecoveryFn } from '../shared/Function';
-import { Maybe } from './Maybe';
+import { Maybe, NotNullAndUndefined, isNotNullAndUndefined } from './Maybe';
 import { expectNotNullAndUndefined } from './expect';
 import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE } from './ErrorMessage';
 
@@ -10,8 +10,8 @@ import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_MAYBE } from './ErrorMessage';
  *  * The result of _def_ must not be `Maybe<*>`.
  *  * If the result of _def_ is `null` or `undefined`, throw `TypeError`.
  */
-export function unwrapOrElseFromMaybe<T>(v: Maybe<T>, def: RecoveryFn<T>): T {
-    if (v !== undefined && v !== null) {
+export function unwrapOrElseFromMaybe<T>(v: Maybe<T>, def: RecoveryFn<T>): NotNullAndUndefined<T> {
+    if (isNotNullAndUndefined(v)) {
         return v;
     }
     else {

--- a/src/Nullable/Nullable.ts
+++ b/src/Nullable/Nullable.ts
@@ -2,7 +2,7 @@ export type NotNull<T> = T extends null ? never : T;
 
 export type Nullable<T> = T | null;
 
-export function isNotNull<T>(v: Nullable<T>): v is T {
+export function isNotNull<T>(v: Nullable<T>): v is NotNull<T> {
     return v !== null;
 }
 

--- a/src/Nullable/Nullable.ts
+++ b/src/Nullable/Nullable.ts
@@ -1,5 +1,22 @@
 export type NotNull<T> = T extends null ? never : T;
 
+// XXX:
+// If we define `type Nullable<T> = NotNull<T> | null`,
+// the following case would be compile error.
+//
+// ``` typescript
+//  function bar<T>(input: T): Nullable<T> {
+//      if (Math.random() > 0.5) {
+//          return input; // <- compile error.
+//          // Type 'T' is not assignable to type 'Nullable<T>'.
+//          // Type 'T' is not assignable to type 'NotNull<T>'.ts(2322)
+//      }
+//      return null;
+//  }
+//  ```
+//
+// This is less ergonomic with generics.
+// So we don't define this as `NotNull<T> | null`.
 export type Nullable<T> = T | null;
 
 export function isNotNull<T>(v: Nullable<T>): v is NotNull<T> {

--- a/src/Nullable/expect.ts
+++ b/src/Nullable/expect.ts
@@ -1,13 +1,13 @@
-import { Nullable } from './Nullable';
+import { Nullable, NotNull, isNotNull } from './Nullable';
 
 /**
  *  Return _v_ as `T` if the passed _v_ is not `null`.
  *  Otherwise, throw `TypeError` with the passed `msg`.
  */
-export function expectNotNull<T>(v: Nullable<T>, msg: string): T | never {
-    if (v === null) {
-        throw new TypeError(msg);
+export function expectNotNull<T>(v: Nullable<T>, msg: string): NotNull<T> {
+    if (isNotNull(v)) {
+        return v;
     }
 
-    return v;
+    throw new TypeError(msg);
 }

--- a/src/Nullable/map.ts
+++ b/src/Nullable/map.ts
@@ -1,7 +1,7 @@
 import { expectNotNull } from './expect';
 import { ERR_MSG_SELECTOR_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE } from './ErrorMessage';
 import { MapFn } from '../shared/Function';
-import { Nullable } from './Nullable';
+import { Nullable, NotNull } from './Nullable';
 
 /**
  *  Return the result of _selector_ with using _src_ as an argument for it if _src_ is not `null`,
@@ -11,7 +11,7 @@ import { Nullable } from './Nullable';
  *      * If you'd like return `Nullable<*>` as `U`, use `andThen()`.
  *      * If the result of _selector_ is `null`, this throw an `Error`.
  */
-export function mapForNullable<T, U>(src: Nullable<T>, selector: MapFn<T, U>): Nullable<U> {
+export function mapForNullable<T, U>(src: Nullable<T>, selector: MapFn<T, NotNull<U>>): Nullable<U> {
     if (src !== null) {
         const r = selector(src);
         // XXX:

--- a/src/Nullable/mapOr.ts
+++ b/src/Nullable/mapOr.ts
@@ -1,4 +1,4 @@
-import { Nullable } from './Nullable';
+import { Nullable, NotNull } from './Nullable';
 import { expectNotNull } from './expect';
 import { ERR_MSG_SELECTOR_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE, ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_NULLABLE } from './ErrorMessage';
 import { MapFn } from '../shared/Function';
@@ -14,7 +14,7 @@ import { MapFn } from '../shared/Function';
  *      * If the result of _def_ is `null`, this throw an `Error`.
  *  * If you'd like to accept `Nullable<*>` as `U`, use a combination `andThen()` and `or()`.
  */
-export function mapOrForNullable<T, U>(src: Nullable<T>, def: U, selector: MapFn<T, U>): U {
+export function mapOrForNullable<T, U>(src: Nullable<T>, def: U, selector: MapFn<T, U>): NotNull<U> {
     let r: U;
     let msg = '';
     if (src !== null) {

--- a/src/Nullable/mapOr.ts
+++ b/src/Nullable/mapOr.ts
@@ -14,7 +14,7 @@ import { MapFn } from '../shared/Function';
  *      * If the result of _def_ is `null`, this throw an `Error`.
  *  * If you'd like to accept `Nullable<*>` as `U`, use a combination `andThen()` and `or()`.
  */
-export function mapOrForNullable<T, U>(src: Nullable<T>, def: U, selector: MapFn<T, U>): NotNull<U> {
+export function mapOrForNullable<T, U>(src: Nullable<T>, def: U, selector: MapFn<T, NotNull<U>>): NotNull<U> {
     let r: U;
     let msg = '';
     if (src !== null) {

--- a/src/Nullable/mapOrElse.ts
+++ b/src/Nullable/mapOrElse.ts
@@ -1,7 +1,7 @@
 import { expectNotNull } from './expect';
 import { ERR_MSG_SELECTOR_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE, ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE } from './ErrorMessage';
 import { MapFn, RecoveryFn } from '../shared/Function';
-import { Nullable } from './Nullable';
+import { Nullable, NotNull } from './Nullable';
 
 /**
  *  Return the result of _selector_ with using _src_ as an argument for it if _src_ is not `null`.
@@ -14,7 +14,7 @@ import { Nullable } from './Nullable';
  *      * If the result of _def_ is null`, this throw an `Error`.
  *  * If you'd like to accept `Nullable<*>` as `U`, use a combination `andThen()` and `orElse()`.
  */
-export function mapOrElseForNullable<T, U>(src: Nullable<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): U {
+export function mapOrElseForNullable<T, U>(src: Nullable<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): NotNull<U> {
     let r: U;
     let msg = '';
     if (src !== null) {

--- a/src/Nullable/mapOrElse.ts
+++ b/src/Nullable/mapOrElse.ts
@@ -14,7 +14,7 @@ import { Nullable, NotNull } from './Nullable';
  *      * If the result of _def_ is null`, this throw an `Error`.
  *  * If you'd like to accept `Nullable<*>` as `U`, use a combination `andThen()` and `orElse()`.
  */
-export function mapOrElseForNullable<T, U>(src: Nullable<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): NotNull<U> {
+export function mapOrElseForNullable<T, U>(src: Nullable<T>, def: RecoveryFn<NotNull<U>>, selector: MapFn<T, NotNull<U>>): NotNull<U> {
     let r: U;
     let msg = '';
     if (src !== null) {

--- a/src/Nullable/unwrap.ts
+++ b/src/Nullable/unwrap.ts
@@ -1,11 +1,11 @@
 import { expectNotNull } from './expect';
-import { Nullable } from './Nullable';
+import { Nullable, NotNull } from './Nullable';
 import { ERR_MSG_UNWRAP_NO_VAL_FOR_NULLABLE } from './ErrorMessage';
 
 /**
  *  Return _v_ as `T` if the passed _v_ is not `null`.
  *  Otherwise, throw `TypeError`.
  */
-export function unwrapNullable<T>(v: Nullable<T>): T | never {
+export function unwrapNullable<T>(v: Nullable<T>): NotNull<T> {
     return expectNotNull(v, ERR_MSG_UNWRAP_NO_VAL_FOR_NULLABLE);
 }

--- a/src/Nullable/unwrapOr.ts
+++ b/src/Nullable/unwrapOr.ts
@@ -1,4 +1,4 @@
-import { Nullable } from './Nullable';
+import { Nullable, NotNull, isNotNull } from './Nullable';
 import { expectNotNull } from './expect';
 import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_NULLABLE } from './ErrorMessage';
 
@@ -9,8 +9,8 @@ import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_NULLABLE } from './ErrorMessage';
  *  * _def_ must not be `Nullable<*>`.
  *  * If the _def_ is `null`, throw `TypeError`.
  */
-export function unwrapOrFromNullable<T>(v: Nullable<T>, def: T): T {
-    if (v !== null) {
+export function unwrapOrFromNullable<T>(v: Nullable<T>, def: T): NotNull<T> {
+    if (isNotNull(v)) {
         return v;
     }
     else {

--- a/src/Nullable/unwrapOr.ts
+++ b/src/Nullable/unwrapOr.ts
@@ -9,7 +9,7 @@ import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_NULLABLE } from './ErrorMessage';
  *  * _def_ must not be `Nullable<*>`.
  *  * If the _def_ is `null`, throw `TypeError`.
  */
-export function unwrapOrFromNullable<T>(v: Nullable<T>, def: T): NotNull<T> {
+export function unwrapOrFromNullable<T>(v: Nullable<T>, def: NotNull<T>): NotNull<T> {
     if (isNotNull(v)) {
         return v;
     }

--- a/src/Nullable/unwrapOrElse.ts
+++ b/src/Nullable/unwrapOrElse.ts
@@ -11,7 +11,7 @@ import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE } from './ErrorMessage'
  *      * If you try to recover the value, use `orElse()`
  *  * If the result of _def_ is `null`, throw `TypeError`.
  */
-export function unwrapOrElseFromNullable<T>(v: Nullable<T>, def: RecoveryFn<T>): NotNull<T> {
+export function unwrapOrElseFromNullable<T>(v: Nullable<T>, def: RecoveryFn<NotNull<T>>): NotNull<T> {
     if (isNotNull(v)) {
         return v;
     }

--- a/src/Nullable/unwrapOrElse.ts
+++ b/src/Nullable/unwrapOrElse.ts
@@ -1,5 +1,5 @@
 import { RecoveryFn } from '../shared/Function';
-import { Nullable } from './Nullable';
+import { Nullable, NotNull, isNotNull } from './Nullable';
 import { expectNotNull } from './expect';
 import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE } from './ErrorMessage';
 
@@ -11,8 +11,8 @@ import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_NULLABLE } from './ErrorMessage'
  *      * If you try to recover the value, use `orElse()`
  *  * If the result of _def_ is `null`, throw `TypeError`.
  */
-export function unwrapOrElseFromNullable<T>(v: Nullable<T>, def: RecoveryFn<T>): T {
-    if (v !== null) {
+export function unwrapOrElseFromNullable<T>(v: Nullable<T>, def: RecoveryFn<T>): NotNull<T> {
+    if (isNotNull(v)) {
         return v;
     }
     else {

--- a/src/Undefinable/Undefinable.ts
+++ b/src/Undefinable/Undefinable.ts
@@ -1,5 +1,22 @@
 export type NotUndefined<T> = T extends undefined ? never : T;
 
+// XXX:
+// If we define `type Undefinable<T> = NotUndefined<T> | null`,
+// the following case would be compile error.
+//
+// ``` typescript
+//  function bar<T>(input: T): Undefinable<T> {
+//      if (Math.random() > 0.5) {
+//          return input; // <- compile error.
+//          // Type 'T' is not assignable to type 'Undefinable<T>'.
+//          // Type 'T' is not assignable to type 'NotUndefined<T>'.ts(2322)
+//      }
+//      return null;
+//  }
+//  ```
+//
+// This is less ergonomic with generics.
+// So we don't define this as `NotUndefined<T> | null`.
 export type Undefinable<T> = T | undefined;
 
 export function isNotUndefined<T>(v: Undefinable<T>): v is NotUndefined<T> {

--- a/src/Undefinable/Undefinable.ts
+++ b/src/Undefinable/Undefinable.ts
@@ -2,7 +2,7 @@ export type NotUndefined<T> = T extends undefined ? never : T;
 
 export type Undefinable<T> = T | undefined;
 
-export function isNotUndefined<T>(v: Undefinable<T>): v is T {
+export function isNotUndefined<T>(v: Undefinable<T>): v is NotUndefined<T> {
     return v !== undefined;
 }
 

--- a/src/Undefinable/expect.ts
+++ b/src/Undefinable/expect.ts
@@ -1,12 +1,13 @@
-import { Undefinable } from './Undefinable';
+import { Undefinable, NotUndefined, isNotUndefined } from './Undefinable';
 
 /**
  *  Return _v_ as `T` if the passed _v_ is not `undefined`.
  *  Otherwise, throw `TypeError` with the passed `msg`.
  */
-export function expectNotUndefined<T>(v: Undefinable<T>, msg: string): T | never {
-    if (v === undefined) {
-        throw new TypeError(msg);
+export function expectNotUndefined<T>(v: Undefinable<T>, msg: string): NotUndefined<T> {
+    if (isNotUndefined(v)) {
+        return v;
     }
-    return v;
+
+    throw new TypeError(msg);
 }

--- a/src/Undefinable/map.ts
+++ b/src/Undefinable/map.ts
@@ -1,7 +1,7 @@
 import { ERR_MSG_SELECTOR_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessage';
 import { expectNotUndefined } from './expect';
 import { MapFn } from '../shared/Function';
-import { Undefinable } from './Undefinable';
+import { Undefinable, NotUndefined } from './Undefinable';
 
 /**
  *  Return the result of _selector_ with using _src_ as an argument for it if _src_ is not `undefined`,
@@ -11,7 +11,7 @@ import { Undefinable } from './Undefinable';
  *      * If you'd like return `Undefinable<*>` as `U`, use `andThen()`.
  *      * If the result of _selector_ is `undefined`, this throw an `Error`.
  */
-export function mapForUndefinable<T, U>(src: Undefinable<T>, selector: MapFn<T, U>): Undefinable<U> {
+export function mapForUndefinable<T, U>(src: Undefinable<T>, selector: MapFn<T, NotUndefined<U>>): Undefinable<U> {
     if (src !== undefined) {
         const r = selector(src);
         // XXX:

--- a/src/Undefinable/mapOr.ts
+++ b/src/Undefinable/mapOr.ts
@@ -14,7 +14,7 @@ import { Undefinable, NotUndefined } from './Undefinable';
  *      * If the result of _def_ is `undefined`, this throw an `Error`.
  *  * If you'd like to accept `Undefinable<*>` as `U`, use a combination `andThen()` and `or()`.
  */
-export function mapOrForUndefinable<T, U>(src: Undefinable<T>, def: U, selector: MapFn<T, U>): NotUndefined<U> {
+export function mapOrForUndefinable<T, U>(src: Undefinable<T>, def: NotUndefined<U>, selector: MapFn<T, NotUndefined<U>>): NotUndefined<U> {
     let r: U;
     let msg = '';
     if (src !== undefined) {

--- a/src/Undefinable/mapOr.ts
+++ b/src/Undefinable/mapOr.ts
@@ -1,7 +1,7 @@
 import { ERR_MSG_SELECTOR_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE, ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessage';
 import { expectNotUndefined } from './expect';
 import { MapFn } from '../shared/Function';
-import { Undefinable } from './Undefinable';
+import { Undefinable, NotUndefined } from './Undefinable';
 
 /**
  *  Return the result of _selector_ with using _src_ as an argument for it if _src_ is not `undefined`.
@@ -14,7 +14,7 @@ import { Undefinable } from './Undefinable';
  *      * If the result of _def_ is `undefined`, this throw an `Error`.
  *  * If you'd like to accept `Undefinable<*>` as `U`, use a combination `andThen()` and `or()`.
  */
-export function mapOrForUndefinable<T, U>(src: Undefinable<T>, def: U, selector: MapFn<T, U>): U {
+export function mapOrForUndefinable<T, U>(src: Undefinable<T>, def: U, selector: MapFn<T, U>): NotUndefined<U> {
     let r: U;
     let msg = '';
     if (src !== undefined) {

--- a/src/Undefinable/mapOrElse.ts
+++ b/src/Undefinable/mapOrElse.ts
@@ -14,7 +14,7 @@ import { Undefinable, NotUndefined } from './Undefinable';
  *      * If the result of _def_ is undefined`, this throw an `Error`.
  *  * If you'd like to accept `Undefinable<*>` as `U`, use a combination `andThen()` and `orElse()`.
  */
-export function mapOrElseForUndefinable<T, U>(src: Undefinable<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): NotUndefined<U> {
+export function mapOrElseForUndefinable<T, U>(src: Undefinable<T>, def: RecoveryFn<NotUndefined<U>>, selector: MapFn<T, NotUndefined<U>>): NotUndefined<U> {
     let r: U;
     let msg = '';
     if (src !== undefined) {

--- a/src/Undefinable/mapOrElse.ts
+++ b/src/Undefinable/mapOrElse.ts
@@ -1,7 +1,7 @@
 import { ERR_MSG_SELECTOR_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE, ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessage';
 import { expectNotUndefined } from './expect';
 import { RecoveryFn, MapFn } from '../shared/Function';
-import { Undefinable } from './Undefinable';
+import { Undefinable, NotUndefined } from './Undefinable';
 
 /**
  *  Return the result of _selector_ with using _src_ as an argument for it if _src_ is not `undefined`.
@@ -14,7 +14,7 @@ import { Undefinable } from './Undefinable';
  *      * If the result of _def_ is undefined`, this throw an `Error`.
  *  * If you'd like to accept `Undefinable<*>` as `U`, use a combination `andThen()` and `orElse()`.
  */
-export function mapOrElseForUndefinable<T, U>(src: Undefinable<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): U {
+export function mapOrElseForUndefinable<T, U>(src: Undefinable<T>, def: RecoveryFn<U>, selector: MapFn<T, U>): NotUndefined<U> {
     let r: U;
     let msg = '';
     if (src !== undefined) {

--- a/src/Undefinable/unwrap.ts
+++ b/src/Undefinable/unwrap.ts
@@ -1,11 +1,11 @@
 import { expectNotUndefined } from './expect';
-import { Undefinable } from './Undefinable';
+import { Undefinable, NotUndefined } from './Undefinable';
 import { ERR_MSG_UNWRAP_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessage';
 
 /**
  *  Return _v_ as `T` if the passed _v_ is not `undefined`.
  *  Otherwise, throw `TypeError`.
  */
-export function unwrapUndefinable<T>(v: Undefinable<T>): T | never {
+export function unwrapUndefinable<T>(v: Undefinable<T>): NotUndefined<T> {
     return expectNotUndefined(v, ERR_MSG_UNWRAP_NO_VAL_FOR_UNDEFINABLE);
 }

--- a/src/Undefinable/unwrapOr.ts
+++ b/src/Undefinable/unwrapOr.ts
@@ -9,7 +9,7 @@ import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessage';
  *  * _def_ must not be `Undefinable<*>`.
  *  * If the result of _def_ is `undefined`, throw `TypeError`.
  */
-export function unwrapOrFromUndefinable<T>(v: Undefinable<T>, def: T): NotUndefined<T> {
+export function unwrapOrFromUndefinable<T>(v: Undefinable<T>, def: NotUndefined<T>): NotUndefined<T> {
     if (isNotUndefined(v)) {
         return v;
     }

--- a/src/Undefinable/unwrapOr.ts
+++ b/src/Undefinable/unwrapOr.ts
@@ -1,4 +1,4 @@
-import { Undefinable } from './Undefinable';
+import { Undefinable, NotUndefined, isNotUndefined } from './Undefinable';
 import { expectNotUndefined } from './expect';
 import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessage';
 
@@ -9,8 +9,8 @@ import { ERR_MSG_DEF_MUST_NOT_BE_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessage';
  *  * _def_ must not be `Undefinable<*>`.
  *  * If the result of _def_ is `undefined`, throw `TypeError`.
  */
-export function unwrapOrFromUndefinable<T>(v: Undefinable<T>, def: T): T {
-    if (v !== undefined) {
+export function unwrapOrFromUndefinable<T>(v: Undefinable<T>, def: T): NotUndefined<T> {
+    if (isNotUndefined(v)) {
         return v;
     }
     else {

--- a/src/Undefinable/unwrapOrElse.ts
+++ b/src/Undefinable/unwrapOrElse.ts
@@ -1,5 +1,5 @@
 import { RecoveryFn } from '../shared/Function';
-import { Undefinable } from './Undefinable';
+import { Undefinable, NotUndefined, isNotUndefined } from './Undefinable';
 import { expectNotUndefined } from './expect';
 import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessage';
 
@@ -11,8 +11,8 @@ import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessa
  *      * If you try to recover the value, use `orElse()`
  *  * If the result of _def_ is `undefined`, throw `TypeError`.
  */
-export function unwrapOrElseFromUndefinable<T>(v: Undefinable<T>, def: RecoveryFn<T>): T {
-    if (v !== undefined) {
+export function unwrapOrElseFromUndefinable<T>(v: Undefinable<T>, def: RecoveryFn<T>): NotUndefined<T> {
+    if (isNotUndefined(v)) {
         return v;
     }
     else {

--- a/src/Undefinable/unwrapOrElse.ts
+++ b/src/Undefinable/unwrapOrElse.ts
@@ -11,7 +11,7 @@ import { ERR_MSG_DEF_MUST_NOT_RETURN_NO_VAL_FOR_UNDEFINABLE } from './ErrorMessa
  *      * If you try to recover the value, use `orElse()`
  *  * If the result of _def_ is `undefined`, throw `TypeError`.
  */
-export function unwrapOrElseFromUndefinable<T>(v: Undefinable<T>, def: RecoveryFn<T>): NotUndefined<T> {
+export function unwrapOrElseFromUndefinable<T>(v: Undefinable<T>, def: RecoveryFn<NotUndefined<T>>): NotUndefined<T> {
     if (isNotUndefined(v)) {
         return v;
     }


### PR DESCRIPTION
By https://github.com/karen-irc/option-t/pull/344, we can ensure the types of function sigunatures statically by marking their _non nullable_.

## Pros

* Make usages more solid and strict.

## Cons

* This might increase a compilation/type checking time in user project by typescript compiler.
    * We need to investigate it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/345)
<!-- Reviewable:end -->
