### PR TITLE
Make `import {} from 'option-t'` meaningless

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "option-t",
   "version": "19.3.0",
   "description": "Option type implementation whose APIs are inspired by Rust's `Option<T>`.",
+  "type": "commonjs",
   "main": "cjs/index.js",
   "files": [
     "CHANGELOG.md",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,0 @@
-export {
-    Option,
-    Some,
-    None,
-    OptionBase,
-    createSome,
-    createNone,
-} from './Option';


### PR DESCRIPTION
* Stop expose `src/Option` via `src/index`.
* This sort the usages with other APIs which this pacakge provides.
* For the future, we might provide all APIs from this entry points

## Related Issue

* https://github.com/karen-irc/option-t/issues/232

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/365)
<!-- Reviewable:end -->
