### PR TITLE
Fix misusing assert.notStrictEqual() in the test for Option<T>.flatMap()

### DIFF
--- a/test/option-t/test_flatmap.js
+++ b/test/option-t/test_flatmap.js
@@ -73,7 +73,7 @@ describe('Option<T>.flatMap()', function(){
                 try {
                     some.flatMap(function(val){
                         const rv = 'hoge';
-                        assert.notStrictEqual(val !== rv);
+                        assert.notStrictEqual(val, rv);
                         return rv;
                     });
                 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/373)
<!-- Reviewable:end -->
