### PR TITLE
Add comments why we don't recommend to use wrapper objects

### DIFF
--- a/src/Option.d.ts
+++ b/src/Option.d.ts
@@ -228,6 +228,20 @@ interface None<T> extends Optionable<T> {
 /**
  *  The Option/Maybe type interface whose APIs are inspired
  *  by Rust's `std::option::Option<T>`.
+ *
+ *  _We recommend to use utility types & functions (`PlainOption/Option<T>`)
+ *  if you don't have to use `instanceof` check and
+ *  you should avoid to expose this object as a public API of your package_
+ *  because `instanceof` checking might not work correctly if a user project has
+ *  multiple version of this package in their dependencies.
+ *  See ([#337](https://github.com/karen-irc/option-t/pull/337)).
+ *
+ *  Furthermore, we don't have a plan to implements a new API aggressively for this object
+ *  because we need to implement it on `.prototype`
+ *  and it might be hard to remove unused methods from `.prototype` on minifying.
+ *  We could resolve this problem for the future release but today is not so.
+ *
+ *  See [#378](https://github.com/karen-irc/option-t/issues/378)
  */
 export type Option<T> = Some<T> | None<T>;
 

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -202,6 +202,20 @@ interface Err<T, E> extends Resultable<T, E> {
 /**
  *  The Result/Either type interface whose APIs are inspired
  *  by Rust's `std::result::Result<T, E>`.
+ *
+ *  _We recommend to use utility types & functions (`PlainResult/Result<T, E>`)
+ *  if you don't have to use `instanceof` check and
+ *  you should avoid to expose this object as a public API of your package_
+ *  because `instanceof` checking might not work correctly if a user project has
+ *  multiple version of this package in their dependencies.
+ *  See ([#337](https://github.com/karen-irc/option-t/pull/337)).
+ *
+ *  Furthermore, we don't have a plan to implements a new API aggressively for this object
+ *  because we need to implement it on `.prototype`
+ *  and it might be hard to remove unused methods from `.prototype` on minifying.
+ *  We could resolve this problem for the future release but today is not so.
+ *
+ *  See [#378](https://github.com/karen-irc/option-t/issues/378)
  */
 export type Result<T, E> = Ok<T, E> | Err<T, E>;
 


### PR DESCRIPTION
We have already written this reason in README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/379)
<!-- Reviewable:end -->
