### PR TITLE
Disallow to pass PlainOption::Option to operators of PlainResult, and vice versa by tagging for objects

### DIFF
--- a/src/PlainOption/Option.ts
+++ b/src/PlainOption/Option.ts
@@ -1,8 +1,16 @@
 export type Option<T> = Some<T> | None;
 
+declare const marker: unique symbol;
+
 export type Some<T> = {
     readonly ok: true;
     readonly val: T;
+
+    // This field makes incompatible the type with `PlainOption::Option`.
+    // We'd like to tread this as like phantom type.
+    // So we don't supply this field actually for the runtime
+    // and this will be used only for static type checking.
+    readonly [marker]: unique symbol;
 };
 
 export function isSome<T>(v: Option<T>): v is Some<T> {
@@ -13,7 +21,11 @@ export function createSome<T>(val: T): Some<T> {
     const r: Some<T> = {
         ok: true,
         val,
-    };
+
+        // For keeping the object structure minimally,
+        // treat `[marker]` field as like "Phantom Type",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
     return r;
 }
 
@@ -30,6 +42,12 @@ export type None = {
     // Even if user will use `const { ok, val }` = None;`, then val will be undefined.
     // It's will not be a problem.
     readonly val?: undefined;
+
+    // This field makes incompatible the type with `PlainOption::Option`.
+    // We'd like to tread this as like phantom type.
+    // So we don't supply this field actually for the runtime
+    // and this will be used only for static type checking.
+    readonly [marker]: unique symbol;
 };
 
 export function isNone<T>(v: Option<T>): v is None {
@@ -40,6 +58,10 @@ export function createNone(): None {
     const r: None = {
         ok: false,
         val: undefined,
-    };
+
+        // For keeping the object structure minimally,
+        // treat `[marker]` field as like "Phantom Type",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
     return r;
 }

--- a/src/PlainResult/Result.ts
+++ b/src/PlainResult/Result.ts
@@ -1,5 +1,7 @@
 export type Result<T, E> = Ok<T> | Err<E>;
 
+declare const marker: unique symbol;
+
 export type Ok<T> = {
     readonly ok: true;
     readonly val: T;
@@ -14,6 +16,12 @@ export type Ok<T> = {
     // Even if user will use `const { ok, err }` = Ok;`, then val will be undefined.
     // It's will not be a problem.
     readonly err?: undefined;
+
+    // This field makes incompatible the type with `PlainOption::Option`.
+    // We'd like to tread this as like phantom type.
+    // So we don't supply this field actually for the runtime
+    // and this will be used only for static type checking.
+    readonly [marker]: unique symbol;
 };
 
 export function isOk<T, E>(v: Result<T, E>): v is Ok<T> {
@@ -25,7 +33,11 @@ export function createOk<T>(val: T): Ok<T> {
         ok: true,
         val,
         err: undefined,
-    };
+
+        // For keeping the object structure minimally,
+        // treat `[marker]` field as like "Phantom Type",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
     return r;
 }
 
@@ -44,6 +56,12 @@ export type Err<E> = {
     readonly val?: undefined;
 
     readonly err: E;
+
+    // This field makes incompatible the type with `PlainOption::Option`.
+    // We'd like to tread this as like phantom type.
+    // So we don't supply this field actually for the runtime
+    // and this will be used only for static type checking.
+    readonly [marker]: unique symbol;
 };
 
 export function isErr<T, E>(v: Result<T, E>): v is Err<E> {
@@ -55,7 +73,11 @@ export function createErr<E>(err: E): Err<E> {
         ok: false,
         val: undefined,
         err: err,
-    };
+
+        // For keeping the object structure minimally,
+        // treat `[marker]` field as like "Phantom Type",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
     return r;
 }
 


### PR DESCRIPTION
Fix https://github.com/karen-irc/option-t/issues/387

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/388)
<!-- Reviewable:end -->
