### PR TITLE
Add the test to ensure properties on objects 

### DIFF
--- a/ava_test/PlainOption/test_object_shape.js
+++ b/ava_test/PlainOption/test_object_shape.js
@@ -14,4 +14,6 @@ test('The shape of PlainOption::None', (t) => {
     const actual = createNone();
     t.false(actual.ok, 'None.ok');
     t.is(actual.val, undefined, 'None.val');
+    // eslint-disable-next-line no-prototype-builtins
+    t.true(actual.hasOwnProperty('val'), '`val` should be added on creating this object to stabilize object\'s Shape/Structure/Hidden Class');
 });

--- a/ava_test/PlainResult/test_object_shape.js
+++ b/ava_test/PlainResult/test_object_shape.js
@@ -10,6 +10,8 @@ test('The shape of PlainResult::Ok', (t) => {
     t.true(actual.ok, 'Ok.ok');
     t.is(actual.val, INNER_VAL, 'Ok.val');
     t.is(actual.err, undefined, 'Ok.err');
+    // eslint-disable-next-line no-prototype-builtins
+    t.true(actual.hasOwnProperty('err'), '`err` should be added on creating this object to stabilize object\'s Shape/Structure/Hidden Class');
 });
 
 test('The shape of PlainResult::Err', (t) => {
@@ -19,5 +21,7 @@ test('The shape of PlainResult::Err', (t) => {
 
     t.false(actual.ok, 'Err.ok');
     t.is(actual.val, undefined, 'Err.val');
+    // eslint-disable-next-line no-prototype-builtins
+    t.true(actual.hasOwnProperty('val'), '`val` should be added on creating this object to stabilize object\'s Shape/Structure/Hidden Class');
     t.is(actual.err, INNER_VAL, 'Err.err');
 });

--- a/src/PlainOption/Option.ts
+++ b/src/PlainOption/Option.ts
@@ -29,6 +29,9 @@ export type None = {
     // and user will not do their operations for a "container" object like this.
     // Even if user will use `const { ok, val }` = None;`, then val will be undefined.
     // It's will not be a problem.
+    //
+    // By these reasons, we don't recommend to create this typed object without this factory function.
+    // You can create this object by hand. But it's fragile for the future change. We don't recommend it.
     readonly val?: undefined;
 };
 

--- a/src/PlainResult/Result.ts
+++ b/src/PlainResult/Result.ts
@@ -13,6 +13,9 @@ export type Ok<T> = {
     // and user will not do their operations for a "container" object like this.
     // Even if user will use `const { ok, err }` = Ok;`, then val will be undefined.
     // It's will not be a problem.
+    //
+    // By these reasons, we don't recommend to create this object without this factory function.
+    // You can create this object by hand. But it's fragile for the future change. We don't recommend it.
     readonly err?: undefined;
 };
 
@@ -41,6 +44,9 @@ export type Err<E> = {
     // and user will not do their operations for a "container" object like this.
     // Even if user will use `const { ok, val }` = Err;`, then val will be undefined.
     // It's will not be a problem.
+    //
+    // By these reasons, we don't recommend to create this typed object without this factory function.
+    // You can create this object by hand. But it's fragile for the future change. We don't recommend it.
     readonly val?: undefined;
 
     readonly err: E;


### PR DESCRIPTION
We add these properties on creating by factory functions to stabilize their object Shape (SpiderMonkey)/Structure (JavaScriptCore)/Hidden Class (V8).

* `PlainOption::None.val`
* `PlainResult::Ok.err`
* `PlainResult::Err.val`

This change adds the test case to ensure to do it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/395)
<!-- Reviewable:end -->
