### PR TITLE
Mark legacy `Option<T>` and `Result<T, E>` as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ yarn add option-t --save
     * plain objects
         * [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./src/PlainOption/)
         * [`Result<T, E>` (`{ ok: true; val: T } | { ok: false; err: E; }`)](./src/PlainResult/)
-* Wrapper objects
+* Wrapper objects ([__*deperecated*__](https://github.com/karen-irc/option-t/issues/459)).
     * [`Option<T>`](./src/Option.d.ts)
     * [`Result<T, E>`](./src/Result.d.ts)
 

--- a/src/Option.d.ts
+++ b/src/Option.d.ts
@@ -164,6 +164,9 @@ interface Optionable<T> {
 }
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  The base object of `Some<T>` and `None<T>`.
  *
  *  XXX:
@@ -226,6 +229,9 @@ interface None<T> extends Optionable<T> {
 }
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  The Option/Maybe type interface whose APIs are inspired
  *  by Rust's `std::option::Option<T>`.
  *

--- a/src/Option.js
+++ b/src/Option.js
@@ -25,6 +25,9 @@
 /* eslint-enable valid-jsdoc */
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  @constructor
  *  @template   T
  *  @param  {boolean}   ok
@@ -298,6 +301,9 @@ OptionBase.prototype = Object.freeze({
 });
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  @template   T
  *  @param  {T}   val
  *  @return    {OptionT<T>}
@@ -308,6 +314,9 @@ export function createSome(val) {
 }
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  @template   T
  *  @return    {OptionT<T>}
  */

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -149,9 +149,14 @@ interface Resultable<T, E> {
     drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
-// XXX:
-// This is only used for the instanceof-basis runtime checking. (e.g. `React.PropTypes.instanceOf()`)
-// You MUST NOT use for other purpose.
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
+ * XXX:
+ * This is only used for the instanceof-basis runtime checking. (e.g. `React.PropTypes.instanceOf()`)
+ * You MUST NOT use for other purpose.
+ */
 export abstract class ResultBase<T, E> implements Resultable<T, E> {
     private readonly _isOk: boolean;
     private readonly _v: T | undefined;
@@ -200,6 +205,9 @@ interface Err<T, E> extends Resultable<T, E> {
 }
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  The Result/Either type interface whose APIs are inspired
  *  by Rust's `std::result::Result<T, E>`.
  *

--- a/src/Result.js
+++ b/src/Result.js
@@ -3,6 +3,9 @@ import { createSome, createNone } from './Option';
 /* eslint-enable valid-jsdoc */
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  @constructor
  *  @template   T, E
  *  @param  {boolean}   ok
@@ -336,6 +339,9 @@ ResultBase.prototype = Object.freeze({
 });
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  @template   T, E
  *  @param  {!T} v
  *  @return    {Result<T, E>}
@@ -346,6 +352,9 @@ export function createOk(v) {
 }
 
 /**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
  *  @template   T, E
  *  @param  {!E} e
  *  @return    {Result<T, E>}


### PR DESCRIPTION
* https://github.com/karen-irc/option-t/issues/459
* Retry https://github.com/karen-irc/option-t/pull/460
    * https://github.com/karen-irc/option-t/pull/461

Motivation
------------

A legacy `Option<T>` and `Result<T, E>` has some problems,

1. Type system
    * The current type system might be a bit odd and it's difficult
      to rewrite them with TypeScript to keep with backward compatibility.
2. Extensibility
    * See https://github.com/karen-irc/option-t/issues/378
3. Complex build system.
    * We use mixed build mode for them. It increase a complexity of our build system.
4. Interoperability
    * See https://github.com/karen-irc/option-t/issues/232

We tried to reduce them for a long time. But I think it's better that we should do this.

1. __API Freeze__
    * Don't add any new features.
2. __Mark as *deprecated*__
    * This does not mean to drop these code.
      But we don't recommend to use them in your new code.

__At first, we marked as deprecated in this change__.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/462)
<!-- Reviewable:end -->
