### PR TITLE
Drop Node.js v10 and replace it by v12 from our CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ yarnpkg_cache_dir: &yarnpkg_cache_dir
 # Executors Definitions
 ###########################################
 executors:
-    nodejs_10_executor:
+    nodejs_12_executor:
         working_directory: *workspace_root
         docker:
-            - image: node:10-buster
+            - image: node:12-buster
         environment:
             YARN_CACHE_FOLDER: *yarnpkg_cache_dir
 
@@ -136,7 +136,7 @@ jobs:
             - *cmd_persist_to_workspace_with_dependency_cache
 
     minimum_build_and_test_for_every_change:
-        executor: nodejs_10_executor
+        executor: nodejs_12_executor
         steps:
             - checkout
             - *cmd_attach_workspace


### PR DESCRIPTION
Node.js v12 has been in LTS.
We can drop v10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/484)
<!-- Reviewable:end -->
