### PR TITLE
Fix all import/export path in esm/

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
     ],
 
     'parserOptions': {
-        'ecmaVersion': 2018,
+        'ecmaVersion': 2020,
     },
 
     'env': {

--- a/tools/babel/babel-plugin-add-mjs-suffix.js
+++ b/tools/babel/babel-plugin-add-mjs-suffix.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const EXTENSION = '.mjs';
+
+function withExtension(name) {
+    return `${name}.mjs`;
+}
+
+function babelAddMjsSuffixPlugin({ types: t }) {
+    return {
+        visitor: {
+            ImportDeclaration(path, _state) {
+                const node = path.node;
+                const source = node.source;
+                if (
+                    t.isStringLiteral(source) &&
+                    source.value.endsWith(EXTENSION)
+                ) {
+                    return;
+                }
+
+                if (node.specifiers.length === 0) {
+                    return;
+                }
+
+                const specifiers = node.specifiers.map((node) => {
+                    const newLocal = t.identifier(node.local.name);
+                    const newImported = t.identifier(node.imported.name);
+                    const newNode = t.importSpecifier(newLocal, newImported);
+                    return newNode;
+                });
+
+                const newSource = t.stringLiteral(withExtension(source.value));
+
+                const declaration = t.importDeclaration(specifiers, newSource);
+                t.assertImportDeclaration(declaration);
+
+                path.replaceWith(declaration);
+            },
+
+            ExportNamedDeclaration(path, _state) {
+                const node = path.node;
+                const source = node.source;
+                if (
+                    t.isStringLiteral(source) &&
+                    source.value.endsWith(EXTENSION)
+                ) {
+                    return;
+                }
+
+                if (node.specifiers.length === 0) {
+                    return;
+                }
+
+                const specifiers = node.specifiers.map((node) => {
+                    t.assertExportSpecifier(node);
+                    const local = node.local;
+                    t.assertIdentifier(local);
+                    const exported = node.exported;
+                    t.assertIdentifier(exported);
+
+                    const newLocal = t.identifier(local.name);
+                    const newExported = t.identifier(exported.name);
+                    const newNode = t.exportSpecifier(newLocal, newExported);
+                    return newNode;
+                });
+
+                const newSource = t.stringLiteral(withExtension(source.value));
+                const declaration = t.exportNamedDeclaration(null, specifiers, newSource);
+                t.assertExportNamedDeclaration(declaration);
+
+                path.replaceWith(declaration);
+            },
+        },
+    };
+}
+
+module.exports = babelAddMjsSuffixPlugin;

--- a/tools/babel/babelrc.mjs.pathrewiter.js
+++ b/tools/babel/babelrc.mjs.pathrewiter.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    'plugins': [
+        './babel-plugin-add-mjs-suffix.js'
+    ],
+};

--- a/tools/esmodule_path_rewrite_tester.js
+++ b/tools/esmodule_path_rewrite_tester.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs').promises;
+const path = require('path');
+
+function parseJSON(text) {
+    try {
+        const o = JSON.parse(text);
+        return o;
+    }
+    catch (_e) {
+        return null;
+    }
+}
+
+async function testAllowToLoadFileAsESM(expectedSet) {
+    const hasError = [];
+    const susccess = [];
+    for await (const filename of expectedSet) {
+        try {
+            await import(filename);
+            expectedSet.delete(filename);
+        }
+        catch (e) {
+            hasError.push(filename);
+            console.error(e);
+        }
+    }
+
+    assert.deepStrictEqual([], susccess, 'Should be success to load all ES Modules');
+    assert.deepStrictEqual([], hasError, 'Unexpected files which could not load as ES Module');
+}
+
+(async function main() {
+    // XXX: Node v12 does not support `import()` by default
+    if (/^v12\.\d+\.\d+$/u.test(process.version)) {
+        return;
+    }
+
+    const OUTDIR = process.env.OUTDIR;
+    assert.strictEqual(typeof OUTDIR, 'string', '$OUTDIR envvar should be string');
+
+    const json = await fs.readFile(path.resolve(__dirname, './pkg_files.json'), {
+        encoding: 'utf8',
+        flag: 'r',
+    });
+    const files = parseJSON(json);
+    assert.notStrictEqual(files, null, 'Fail to parse the file list snapshot');
+
+    const mjsInEsmDir = files.filter((filename) => {
+        return filename.endsWith('.mjs') && filename.startsWith('esm/');
+    });
+
+    const EXPECTED_FILE_SET = new Set(mjsInEsmDir.map((filename) => {
+        const fullpath = path.resolve(OUTDIR, filename);
+        return fullpath;
+    }));
+    assert.notStrictEqual(EXPECTED_FILE_SET.size, 0, 'The expected file list must not be empty');
+
+    await testAllowToLoadFileAsESM(EXPECTED_FILE_SET);
+})().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
Node.js bultin ESM support requires `.mjs` extention for import/export path

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/520)
<!-- Reviewable:end -->
