### PR TITLE
Early return correctly if import/export declaration does not have StrngLiteral as _source_

### DIFF
--- a/tools/babel/babel-plugin-add-mjs-suffix.js
+++ b/tools/babel/babel-plugin-add-mjs-suffix.js
@@ -9,7 +9,7 @@ function withExtension(name) {
 function rewriter(t, path, _state, declarationFactory) {
     const node = path.node;
     const source = node.source;
-    if (t.isStringLiteral(source) && source.value.endsWith(EXTENSION)) {
+    if (!t.isStringLiteral(source) || source.value.endsWith(EXTENSION)) {
         return;
     }
 


### PR DESCRIPTION
This fix to throw TypeError for the case `export { a, b };`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/523)
<!-- Reviewable:end -->
