### PR TITLE
Export all public APIs from `src/index.js`.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+import * as Maybe from './Maybe';
+import * as Nullable from './Nullable';
+import * as Undefinable from './Undefinable';
+import * as PlainOption from './PlainOption';
+import * as PlainResult from './PlainResult';
+
+export {
+    Maybe,
+    Nullable,
+    Undefinable,
+    PlainOption,
+    PlainResult,
+};


### PR DESCRIPTION
* By this change, user will be able to use `import {} from 'option-t';`
  without any redundant path.
* We don't provide class versions `Result` and `Option` by this change.
  They are deprecated APIs.
* Previously, this kind of exporting would prevent tree shaking.
  However, with ES Module, we don't mind such problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/524)
<!-- Reviewable:end -->
