### PR TITLE
Deprecate `option-t/lib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Each of them includes same directoty hierarchy with [under `src`/](./src/).
     - This directory privides commonjs style modules with `.js` extension.
 - `option-t/esm`
     - This directory privides ES modules with `.mjs` extension.
-- `option-t/lib`
+- `option-t/lib` (__*Deprecated*__)
     - This directory privides both of an ES module and a commonjs style module.
         - ES module has `.mjs` extension.
         - CommonJS module has `.js` extension.
@@ -223,6 +223,7 @@ Each of them includes same directoty hierarchy with [under `src`/](./src/).
           But your project also use babel or typescript's downlevel trasnform to transform your code from ES module to Commonjs and
           your project runs unit-tests for transformed code with plain Node.js which only use `require()`.
     - _Please don't use this path if you don't have to use this_.
+        - After Node.js v13.2, we recommend to use ES Module supported natively.
 
 
 ### JSON Representation


### PR DESCRIPTION
Now, Node.js supports an ES Module natively. It's the time to deprecate this dir.

Why did we introduce `option-t/lib`?
---------------------------------------

We introduce this dir to support a following usecase when Node.js did not support ES Module natively.

```javascript
// a,js
import { isNull } from 'option-t/esm/Nullable/Nullable';

console.log(isNull(1));
```

When you would like to this code universally (both Node.js and browsers via webpack or other bundlers), you would face some problem.

If you convert and bundle this code by webpack or others, this code would be run and bundlers do tree shaking nicely.

However, if you transform this code to commonjs or other classic module type
which is able to run on Node.js by using babel or other transformers, it code will not run on your Node.js which does not support an ES Module natively.

If you bundle all code by webpack to run ESM on Node.js which does not support ESM, then you will face another problem that some packages provides another entry points for browsers and their entry points only runs on browsers.

On the other hand, if you use `option-t/cjs/***`, bundler's tree shaking is weak.

So we added `option-t/lib`.

1. If you run this _a.js_ on Node.js after transforming it into commonjs or other formats, `require()` looks up commonjs code provided by _option-t_.
2. If you bundle _a.js_ with webpack and you configured to loop up `.mjs` preferentially, then a bundler use ES Module provided as `.mjs` by _option-t_.

By these hacky trick, [you can get a workaround](https://github.com/karen-irc/option-t/pull/224).

Times are changing
--------------------------

Node.js v12.3 supports ES Module natively without any flags. It still says "this is still experimental", but I think MVP has been concreted.

So we don't have to do the above hacky way.

Of course, it's not a simple.

Node.js still supports import sytax in `.mjs` or you specify to allow ESM in package.json. You will also need add `.mjs` extension to use native supported `import`.

But I think we should mark `option-t/lib` as deprecated and recommend to move to ESM.

Times are changing now.

Will we remove `option-t/lib` immediately?
-------------------------------------------

I don't think so.
At least, we should wait dual (cjs & mjs) package support by Node.js.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/option-t/527)
<!-- Reviewable:end -->
