### PR TITLE
Generate package.json to allow to transform it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ clean_tmp_mjs:
 # Build
 ###########################
 .PHONY: distribution
-distribution: build cp_docs cp_changelog cp_license cp_readme cp_manifest
+distribution: build cp_docs cp_changelog cp_license cp_readme generate_manifest
 
 .PHONY: build
 build: build_cjs build_esm build_mixedlib ## Build all targets.
@@ -143,9 +143,11 @@ cp_license: clean_dist
 cp_readme: clean_dist
 	$(NPM_BIN)/cpx '$(CURDIR)/README.md' $(DIST_DIR)
 
-.PHONY: cp_manifest
-cp_manifest: clean_dist
-	$(NPM_BIN)/cpx '$(CURDIR)/package.json' $(DIST_DIR)
+.PHONY: generate_manifest
+generate_manifest: clean_dist
+	INPUT_MANIFEST_PATH=$(CURDIR)/package.json \
+    OUTDIR=$(DIST_DIR) \
+    $(NODE_BIN) $(CURDIR)/tools/package_json_rewriter/main.js
 
 
 ###########################
@@ -163,7 +165,7 @@ eslint:
 # Test
 ###########################
 .PHONY: test
-test: lint build run_ava test_distribution_contain_all test_esmodule_path_rewrite ## Run all tests
+test: lint build run_ava test_distribution_contain_all test_esmodule_path_rewrite test_package_json_rewrite ## Run all tests
 
 .PHONY: build_test
 build_test: build clean_test_cache
@@ -196,6 +198,14 @@ test_esmodule_path_rewrite: distribution
 .PHONY: run_test_esmodule_path_rewrite
 run_test_esmodule_path_rewrite:
 	OUTDIR=$(DIST_DIR) $(NODE_BIN) $(CURDIR)/tools/esmodule_path_rewrite_tester.js
+
+.PHONY: test_package_json_rewrite
+test_package_json_rewrite: distribution
+	$(MAKE) run_test_package_json_rewrite -C $(CURDIR)
+
+.PHONY: run_test_package_json_rewrite
+run_test_package_json_rewrite:
+	OUTDIR=$(DIST_DIR) $(NODE_BIN) $(CURDIR)/tools/package_json_rewriter/tester.js
 
 
 ###########################

--- a/tools/package_json_rewriter/json.js
+++ b/tools/package_json_rewriter/json.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+
+async function loadFileAsText(baseDir, filepath) {
+    const p = path.resolve(baseDir, filepath);
+    const content = await fs.readFile(p, {
+        encoding: 'utf8',
+        flag: 'r',
+    });
+    return content;
+}
+
+function parseJSON(text) {
+    try {
+        const o = JSON.parse(text);
+        return o;
+    }
+    catch (_e) {
+        return null;
+    }
+}
+
+async function loadPackageJSON(baseDir, filepath) {
+    const text = await loadFileAsText(baseDir, filepath);
+    const json = parseJSON(text);
+    return json;
+}
+
+module.exports = Object.freeze({
+    loadPackageJSON,
+});

--- a/tools/package_json_rewriter/main.js
+++ b/tools/package_json_rewriter/main.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs').promises;
+const path = require('path');
+
+const { loadPackageJSON } = require('./json');
+
+const BASE_DIR = __dirname;
+
+async function writePackageJSON(baseDir, outputPath, content) {
+    assert.strictEqual(outputPath.endsWith('/'), false, 'outputPath should not be end with `/`');
+    const outputDir = path.resolve(baseDir, outputPath);
+    const p = path.resolve(baseDir, outputPath + '/package.json');
+
+    const INDENT = 4;
+    const text = JSON.stringify(content, null, INDENT);
+
+    await fs.mkdir(outputDir, {
+        recursive: true,
+    });
+
+    await fs.appendFile(p, text, {
+        encoding: 'utf8',
+    });
+}
+
+(async function main() {
+    const OUTDIR = process.env.OUTDIR;
+    assert.strictEqual(typeof OUTDIR, 'string', '$OUTDIR envvar should be string');
+
+    const INPUT_MANIFEST_PATH = process.env.INPUT_MANIFEST_PATH;
+    assert.strictEqual(typeof INPUT_MANIFEST_PATH, 'string', '$MANIFEST_PATH envvar should be string');
+
+    const json = await loadPackageJSON(BASE_DIR, INPUT_MANIFEST_PATH);
+    assert.notStrictEqual(json, null, 'Fail to parse the file list snapshot');
+
+    const TRANSFORMERS = [];
+    for (const transforer of TRANSFORMERS) {
+        // eslint-disable-next-line no-await-in-loop
+        await transforer(json);
+    }
+
+    await writePackageJSON(BASE_DIR, OUTDIR, json);
+})().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/tools/package_json_rewriter/tester.js
+++ b/tools/package_json_rewriter/tester.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('assert');
+
+const { loadPackageJSON } = require('./json');
+
+const BASE_DIR = __dirname;
+
+function loadCJS(outDir, file) {
+    const modulepath = `${outDir}/${file}`;
+    // eslint-disable-next-line global-require
+    require(modulepath);
+}
+
+async function loadESM(outDir, file) {
+    // XXX: Node v12 does not support `import()` by default
+    if (/^v12\.\d+\.\d+$/u.test(process.version)) {
+        return;
+    }
+
+    const modulepath = `${outDir}/${file}`;
+    await import(modulepath);
+}
+
+async function loadJSFileAsModule(outDir, file) {
+    if (file.endsWith('.js')) {
+        loadCJS(outDir, file);
+    }
+    else if (file.endsWith('.mjs')) {
+        await loadESM(outDir, file);
+    }
+    else {
+        throw Error(`${file} is not unknown module type`);
+    }
+}
+
+(async function main() {
+    const OUTDIR = process.env.OUTDIR;
+    assert.strictEqual(typeof OUTDIR, 'string', '$OUTDIR envvar should be string');
+
+    const json = await loadPackageJSON(BASE_DIR, '../pkg_files.json');
+    assert.strictEqual(Array.isArray(json), true, '`json` should be Array');
+
+    const cjsFileList = [];
+    const esmFileList = [];
+    const libFileList = [];
+    for (const file of json) {
+        if (file.endsWith('.d.ts')) {
+            continue;
+        }
+
+        if (file.startsWith('cjs/')) {
+            cjsFileList.push(file);
+        }
+        else if (file.startsWith('esm/')) {
+            esmFileList.push(file);
+        }
+        else if (file.startsWith('lib/')) {
+            libFileList.push(file);
+        }
+        else {
+            continue;
+        }
+    }
+
+    for (const file of cjsFileList) {
+        loadCJS(OUTDIR, file);
+    }
+
+    for (const file of esmFileList) {
+        // eslint-disable-next-line no-await-in-loop
+        await loadESM(OUTDIR, file);
+    }
+
+    for (const file of libFileList) {
+        // eslint-disable-next-line no-await-in-loop
+        await loadJSFileAsModule(OUTDIR, file);
+    }
+})().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
We require this to publish this project as Dual CommonJS/ES Module Packages.
We would not like to maintain `exports` field in package.json by hand.

## Related Issue

https://github.com/karen-irc/option-t/issues/421