### PR TITLE
Remove the guard to call import on Node.js 13 or later

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     nodejs_12_executor:
         working_directory: *workspace_root
         docker:
-            - image: node:12-buster
+            - image: node:12.16-buster
         environment:
             YARN_CACHE_FOLDER: *yarnpkg_cache_dir
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     nodejs_12_executor:
         working_directory: *workspace_root
         docker:
-            - image: node:12.16-buster
+            - image: node:12.16-buster-slim
         environment:
             YARN_CACHE_FOLDER: *yarnpkg_cache_dir
 

--- a/tools/esmodule_path_rewrite_tester.js
+++ b/tools/esmodule_path_rewrite_tester.js
@@ -33,11 +33,6 @@ async function testAllowToLoadFileAsESM(expectedSet) {
 }
 
 (async function main() {
-    // XXX: Node v12 does not support `import()` by default
-    if (/^v12\.\d+\.\d+$/u.test(process.version)) {
-        return;
-    }
-
     const OUTDIR = process.env.OUTDIR;
     assert.strictEqual(typeof OUTDIR, 'string', '$OUTDIR envvar should be string');
 

--- a/tools/package_export_tester.js
+++ b/tools/package_export_tester.js
@@ -14,11 +14,6 @@ function loadCJS(file) {
 }
 
 async function loadESM(file) {
-    // XXX: Node v12 does not support `import()` by default
-    if (/^v12\.\d+\.\d+$/u.test(process.version)) {
-        return;
-    }
-
     const modulepath = (file === '.') ? PACKAGE_NAME : `${PACKAGE_NAME}/${file}`;
     await import(modulepath);
 }


### PR DESCRIPTION
By the release node, Node.js 12.16 supports ES Module
natively which Node.js v13 have already supported features.

It's a time to remove the guard.

## Related Issue

* https://github.com/karen-irc/option-t/issues/421