### PR TITLE
Add exist paths to 'exports' fields in package.json

### DIFF
--- a/tools/package_json_rewriter/main.js
+++ b/tools/package_json_rewriter/main.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const fs = require('fs').promises;
 const path = require('path');
 
+const { addExportsFields } = require('./transformer/add_exports_field/main');
 const { loadJSON } = require('./json');
 
 const BASE_DIR = __dirname;
@@ -35,7 +36,9 @@ async function writePackageJSON(baseDir, outputPath, content) {
     const json = await loadJSON(BASE_DIR, INPUT_MANIFEST_PATH);
     assert.notStrictEqual(json, null, 'Fail to parse the file list snapshot');
 
-    const TRANSFORMERS = [];
+    const TRANSFORMERS = [
+        addExportsFields,
+    ];
     for (const transforer of TRANSFORMERS) {
         // eslint-disable-next-line no-await-in-loop
         await transforer(json);

--- a/tools/package_json_rewriter/transformer/add_exports_field/compatibility.js
+++ b/tools/package_json_rewriter/transformer/add_exports_field/compatibility.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const assert = require('assert');
+
+const { loadJSON } = require('../../json');
+
+function filterJSDir(histricalPathInfo) {
+    assert.ok(Array.isArray(histricalPathInfo));
+
+    const jsDir = histricalPathInfo.filter((filepath) => {
+        if (!(/^(cjs|esm|lib)\//u).test(filepath)) {
+            return false;
+        }
+
+        if (!(/^.+\.(js|mjs|cjs)$/u).test(filepath)) {
+            return false;
+        }
+
+        return true;
+    });
+    return jsDir;
+}
+
+async function loadHistoricalPathInfo(baseDir, filename) {
+    const histricalPathInfo = await loadJSON(baseDir, filename);
+    const histricalJSPathList = filterJSDir(histricalPathInfo);
+    return histricalJSPathList;
+}
+
+function addHistoricalPathToExportsFields(o, histricalJSPathList) {
+    // https://nodejs.org/api/esm.html
+    for (const file of histricalJSPathList) {
+        const filepath = `./${file}`;
+        // eslint-disable-next-line no-param-reassign
+        o[filepath] = filepath;
+
+        const filepathWithoutExtension = filepath.replace(/\.(js|mjs|cjs)$/u, '');
+        // eslint-disable-next-line no-param-reassign
+        o[filepathWithoutExtension] = filepathWithoutExtension;
+    }
+}
+
+module.exports = Object.freeze({
+    loadHistoricalPathInfo,
+    addHistoricalPathToExportsFields,
+});

--- a/tools/package_json_rewriter/transformer/add_exports_field/compatibility.js
+++ b/tools/package_json_rewriter/transformer/add_exports_field/compatibility.js
@@ -34,10 +34,37 @@ function addHistoricalPathToExportsFields(o, histricalJSPathList) {
         // eslint-disable-next-line no-param-reassign
         o[filepath] = filepath;
 
+        // Use cjs for lib/
+        if (filepath.startsWith('./lib/') && filepath.endsWith('.mjs')) {
+            continue;
+        }
+
         const filepathWithoutExtension = filepath.replace(/\.(js|mjs|cjs)$/u, '');
         // eslint-disable-next-line no-param-reassign
-        o[filepathWithoutExtension] = filepathWithoutExtension;
+        o[filepathWithoutExtension] = filepath;
     }
+
+    const DIR_SUBPATH = [
+        'Maybe',
+        'Nullable',
+        'PlainOption',
+        'PlainResult',
+        'Undefinable',
+    ];
+
+    const handleSpecialCaseOfNodeModuleResolution = (list, extension) => {
+        for (const dirpath of list) {
+            const key = `./${dirpath}`;
+
+            // eslint-disable-next-line no-param-reassign
+            o[key] = `${key}/index.${extension}`;
+        }
+    };
+
+    handleSpecialCaseOfNodeModuleResolution(DIR_SUBPATH.map((path) => `cjs/${path}`), 'js');
+    handleSpecialCaseOfNodeModuleResolution(DIR_SUBPATH.map((path) => `esm/${path}`), 'mjs');
+    // Our defult is still commonjs. For lib/, we should use `.js`.
+    handleSpecialCaseOfNodeModuleResolution(DIR_SUBPATH.map((path) => `lib/${path}`), 'js');
 }
 
 module.exports = Object.freeze({

--- a/tools/package_json_rewriter/transformer/add_exports_field/main.js
+++ b/tools/package_json_rewriter/transformer/add_exports_field/main.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { loadHistoricalPathInfo, addHistoricalPathToExportsFields } = require('./compatibility');
+
+const BASE_DIR = __dirname;
+
+async function addExportsFields(json) {
+    const o = Object.create(null);
+
+    const histricalJSPathList = await loadHistoricalPathInfo(BASE_DIR, '../../../pkg_files.json');
+    addHistoricalPathToExportsFields(o, histricalJSPathList);
+
+    // eslint-disable-next-line no-param-reassign
+    json.exports = o;
+}
+
+module.exports = Object.freeze({
+    addExportsFields,
+});


### PR DESCRIPTION
## Motivation

By the behavior of Node.js v13.8, if we add `exports` field once even if its object is empty `{}`, user could not load all subpaths by `option-t/esm/Bar/Foo`. This causes a breaking change.

As preparing https://github.com/karen-irc/option-t/pull/575, I'd like to add all exist paths to `exports` field in package.json once. This keep backward compatibility.

By contrast with conditional exports, `exports` field does not emit any warning. I seem we can regard it as stable.

## Related Issues

* https://github.com/karen-irc/option-t/pull/575
* https://github.com/karen-irc/option-t/issues/421
