### PR TITLE
Fix `ERR_PACKAGE_PATH_NOT_EXPORTED` error on loading `option-t`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "22.2.2",
   "description": "Option type implementation whose APIs are inspired by Rust's `Option<T>`.",
   "type": "commonjs",
-  "main": "cjs/index.js",
+  "main": "./cjs/index.js",
   "files": [
     "CHANGELOG.md",
     "cjs/",

--- a/tools/package_json_rewriter/transformer/add_exports_field/main.js
+++ b/tools/package_json_rewriter/transformer/add_exports_field/main.js
@@ -1,14 +1,32 @@
 'use strict';
 
-const { loadHistoricalPathInfo, addHistoricalPathToExportsFields } = require('./compatibility');
+const assert = require('assert');
+
+const {
+    loadHistoricalPathInfo,
+    addHistoricalPathToExportsFields,
+} = require('./compatibility');
 
 const BASE_DIR = __dirname;
+
+function addMainFieldFromPackageJSON(targetObject, manifestInfo) {
+    const mainPath = manifestInfo.main;
+    assert.strictEqual(typeof mainPath, 'string', `package.json's 'main' field is not string`);
+    assert.ok(mainPath.startsWith('./'), `package.json's 'main' field should start with ./`);
+
+    // eslint-disable-next-line no-param-reassign
+    targetObject['.'] = mainPath;
+}
 
 async function addExportsFields(json) {
     const o = Object.create(null);
 
     const histricalJSPathList = await loadHistoricalPathInfo(BASE_DIR, '../../../pkg_files.json');
     addHistoricalPathToExportsFields(o, histricalJSPathList);
+
+    // For the future, we may have a chance to remove this
+    // when https://github.com/nodejs/node/issues/32107/ has been fixed.
+    addMainFieldFromPackageJSON(o, json);
 
     // eslint-disable-next-line no-param-reassign
     json.exports = o;


### PR DESCRIPTION
This error happens by this change in [Node.js v13.10](https://github.com/nodejs/node/pull/31625) and I think we can regard this problem as the regression of this library.

For the future, we should wait https://github.com/nodejs/node/issues/32107 but it is still in progress.
This patch will try to workaround for it.

## Reference

* https://github.com/nodejs/node/pull/31625
* https://github.com/nodejs/node/issues/32107
* https://github.com/babel/babel/issues/11216