### PR TITLE
Run to test for 'exports' field in package.json on GitHub Actions

### DIFF
--- a/ .github/workflows/ci_packaging.yml
+++ b/ .github/workflows/ci_packaging.yml
@@ -1,0 +1,37 @@
+name: Test for 'exports' field in package.json
+on:
+  push:
+    branches-ignore:
+      # These branches are used by bors-n
+      - staging.tmp
+      - trying.tmp
+    tags-ignore:
+      - v*.*.*
+  pull_request:
+    branches-ignore:
+      # These branches are used by bors-n
+      - staging.tmp
+      - trying.tmp
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+  
+    - name: Install dependencies
+      run: yarn install
+
+    - name: Test to import by path names
+      run: make test_package_install -j
+      env:
+        CI: true

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,5 +22,8 @@ indent_size = 4
 [.circleci/**.yml]
 indent_size = 4
 
+[.github/workflows/**.yml]
+indent_size = 2
+
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
For matrix build, GitHub Actions is better than CircleCI.