### PR TITLE
Enable tests using dynamic import for Node v12

### DIFF
--- a/tools/esmodule_path_rewrite_tester.js
+++ b/tools/esmodule_path_rewrite_tester.js
@@ -33,11 +33,6 @@ async function testAllowToLoadFileAsESM(expectedSet) {
 }
 
 (async function main() {
-    // XXX: Node v12 does not support `import()` by default
-    if (/^v12\.\d+\.\d+$/u.test(process.version)) {
-        return;
-    }
-
     const OUTDIR = process.env.OUTDIR;
     assert.strictEqual(typeof OUTDIR, 'string', '$OUTDIR envvar should be string');
 

--- a/tools/package_export_tester.js
+++ b/tools/package_export_tester.js
@@ -14,11 +14,6 @@ function loadCJS(file) {
 }
 
 async function loadESM(file) {
-    // XXX: Node v12 does not support `import()` by default
-    if (/^v12\.\d+\.\d+$/u.test(process.version)) {
-        return;
-    }
-
     const modulepath = (file === '.') ? PACKAGE_NAME : `${PACKAGE_NAME}/${file}`;
     await import(modulepath);
 }


### PR DESCRIPTION
Node v12.17 unflagged ESM support
https://nodejs.org/en/blog/release/v12.17.0/