### PR TITLE
WIP: Clarify meanings of type parameters for PlainResult

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -6,30 +6,6 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require('path');
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { rules } = require('../tools/eslint/eslintrc_typescript');
-const KEY_NAMING_CONVENTION = '@typescript-eslint/naming-convention';
-
-// We allow `K` or `V` forms to avoid to rewrite type parameters.
-const newNamingConventionRule = [...rules[KEY_NAMING_CONVENTION]].map((item) => {
-    if (typeof item === 'string') {
-        return item;
-    }
-
-    if (item.selector !== 'typeParameter') {
-        return item;
-    }
-
-    return {
-        'selector': 'typeParameter',
-        'format': ['PascalCase'],
-        'custom': {
-            'regex': '(^[A-Z]\\d?$|^T[A-Z][a-zA-Z]+\\d?$)',
-            'match': true,
-        },
-    };
-});
-
 // ESLint Configuration Files enables to include comments.
 // http://eslint.org/docs/configuring/#comments-in-configuration-files
 module.exports = {
@@ -49,6 +25,5 @@ module.exports = {
     },
 
     'rules': {
-        [KEY_NAMING_CONVENTION]: newNamingConventionRule,
     }
 };

--- a/src/PlainResult/Result.ts
+++ b/src/PlainResult/Result.ts
@@ -1,4 +1,4 @@
-export type Result<T, E> = Ok<T> | Err<E>;
+export type Result<T, TError> = Ok<T> | Err<TError>;
 
 export type Ok<T> = {
     readonly ok: true;
@@ -19,7 +19,7 @@ export type Ok<T> = {
     readonly err?: undefined;
 };
 
-export function isOk<T, E>(v: Result<T, E>): v is Ok<T> {
+export function isOk<T, TError>(v: Result<T, TError>): v is Ok<T> {
     return v.ok;
 }
 
@@ -32,7 +32,7 @@ export function createOk<T>(val: T): Ok<T> {
     return r;
 }
 
-export type Err<E> = {
+export type Err<TError> = {
     readonly ok: false;
 
     // To keep the same shape (hidden class or structure) with Ok<T>,
@@ -49,15 +49,15 @@ export type Err<E> = {
     // You can create this object by hand. But it's fragile for the future change. We don't recommend it.
     readonly val?: undefined;
 
-    readonly err: E;
+    readonly err: TError;
 };
 
-export function isErr<T, E>(v: Result<T, E>): v is Err<E> {
+export function isErr<T, TError>(v: Result<T, TError>): v is Err<TError> {
     return !v.ok;
 }
 
-export function createErr<E>(err: E): Err<E> {
-    const r: Err<E> = {
+export function createErr<TError>(err: TError): Err<TError> {
+    const r: Err<TError> = {
         ok: false,
         val: undefined,
         err: err,

--- a/src/PlainResult/and.ts
+++ b/src/PlainResult/and.ts
@@ -4,6 +4,6 @@ import { Result } from './Result';
  *  Return _b_ if _a_ is `Ok(T)`.
  *  Otherwise, return _a_.
  */
-export function andForResult<T, U, E>(a: Result<T, E>, b: Result<U, E>): Result<U, E> {
+export function andForResult<T, U, TError>(a: Result<T, TError>, b: Result<U, TError>): Result<U, TError> {
     return a.ok ? b : a;
 }

--- a/src/PlainResult/andThen.ts
+++ b/src/PlainResult/andThen.ts
@@ -5,16 +5,16 @@ export type FlatmapOkFn<T, U, TError> = MapFn<T, Result<U, TError>>;
 
 /**
  *  Returns `Err(TError)` if the _src_ is `Err(TError)`,
- *  otherwise calls _selector_ with the value and returns the result.
+ *  otherwise calls _fn_ with the value and returns the result.
  *
  *  XXX:
  *  Some languages call this operation flatmap.
  *  But we don't provide `flatMap()` as alias of this function
  *  to sort with other APIs.
  */
-export function andThenForResult<T, U, TError>(src: Result<T, TError>, selector: FlatmapOkFn<T, U, TError>): Result<U, TError> {
+export function andThenForResult<T, U, TError>(src: Result<T, TError>, fn: FlatmapOkFn<T, U, TError>): Result<U, TError> {
     if (src.ok) {
-        const r = selector(src.val);
+        const r = fn(src.val);
         return r;
     }
     else {

--- a/src/PlainResult/andThen.ts
+++ b/src/PlainResult/andThen.ts
@@ -1,10 +1,10 @@
 import { MapFn } from '../shared/Function';
 import { Result } from './Result';
 
-export type FlatmapOkFn<T, U, E> = MapFn<T, Result<U, E>>;
+export type FlatmapOkFn<T, U, TError> = MapFn<T, Result<U, TError>>;
 
 /**
- *  Returns `Err(E)` if the _src_ is `Err(E)`,
+ *  Returns `Err(TError)` if the _src_ is `Err(TError)`,
  *  otherwise calls _selector_ with the value and returns the result.
  *
  *  XXX:
@@ -12,7 +12,7 @@ export type FlatmapOkFn<T, U, E> = MapFn<T, Result<U, E>>;
  *  But we don't provide `flatMap()` as alias of this function
  *  to sort with other APIs.
  */
-export function andThenForResult<T, U, E>(src: Result<T, E>, selector: FlatmapOkFn<T, U, E>): Result<U, E> {
+export function andThenForResult<T, U, TError>(src: Result<T, TError>, selector: FlatmapOkFn<T, U, TError>): Result<U, TError> {
     if (src.ok) {
         const r = selector(src.val);
         return r;

--- a/src/PlainResult/drop.ts
+++ b/src/PlainResult/drop.ts
@@ -4,7 +4,7 @@ import { Result, Ok, Err } from './Result';
 import { asMutResult } from './asMut';
 
 type MutOk<T> = Mutable<Ok<T>>;
-type MutErr<E> = Mutable<Err<E>>;
+type MutErr<TError> = Mutable<Err<TError>>;
 
 /**
  *  mutators ared called for the inputted _v_.
@@ -27,7 +27,7 @@ type MutErr<E> = Mutable<Err<E>>;
  *  and this API is designed to use as a destructor or similar fashions.
  *  So if you call this for same object more than once, your code might contain "double free" problem.
  */
-export function unsafeDropBothForResult<T, E>(v: Result<T, E>, okMutator: TapFn<MutOk<T>>, errMutator: TapFn<MutErr<E>>): void {
+export function unsafeDropBothForResult<T, TError>(v: Result<T, TError>, okMutator: TapFn<MutOk<T>>, errMutator: TapFn<MutErr<TError>>): void {
     const mutable = asMutResult(v);
     if (mutable.ok) {
         okMutator(mutable);
@@ -55,7 +55,7 @@ export function unsafeDropBothForResult<T, E>(v: Result<T, E>, okMutator: TapFn<
  *  and this API is designed to use as a destructor or similar fashions.
  *  So if you call this for same object more than once, your code might contain "double free" problem.
  */
-export function unsafeDropOkForResult<T, E>(v: Result<T, E>, okMutator: TapFn<MutOk<T>>): void {
+export function unsafeDropOkForResult<T, TError>(v: Result<T, TError>, okMutator: TapFn<MutOk<T>>): void {
     return unsafeDropBothForResult(v, okMutator, () => {});
 }
 
@@ -78,6 +78,6 @@ export function unsafeDropOkForResult<T, E>(v: Result<T, E>, okMutator: TapFn<Mu
  *  and this API is designed to use as a destructor or similar fashions.
  *  So if you call this for same object more than once, your code might contain "double free" problem.
  */
-export function unsafeDropErrForResult<T, E>(v: Result<T, E>, errMutator: TapFn<MutErr<E>>): void {
+export function unsafeDropErrForResult<T, TError>(v: Result<T, TError>, errMutator: TapFn<MutErr<TError>>): void {
     return unsafeDropBothForResult(v, () => {}, errMutator);
 }

--- a/src/PlainResult/expect.ts
+++ b/src/PlainResult/expect.ts
@@ -4,7 +4,7 @@ import { Result } from './Result';
  *  Return _v_ as `T` if the passed _v_ is `Ok(T)`.
  *  Otherwise, throw `TypeError` with the passed `msg`.
  */
-export function expectIsOk<T, E>(v: Result<T, E>, msg: string): T | never {
+export function expectIsOk<T, TError>(v: Result<T, TError>, msg: string): T | never {
     if (!v.ok) {
         throw new TypeError(msg);
     }
@@ -13,10 +13,10 @@ export function expectIsOk<T, E>(v: Result<T, E>, msg: string): T | never {
 }
 
 /**
- *  Return _v_ as `E` if the passed _v_ is `Err(E)`.
+ *  Return _v_ as `TError` if the passed _v_ is `Err(TError)`.
  *  Otherwise, throw `TypeError` with the passed `msg`.
  */
-export function expectIsErr<T, E>(v: Result<T, E>, msg: string): E | never {
+export function expectIsErr<T, TError>(v: Result<T, TError>, msg: string): TError | never {
     if (v.ok) {
         throw new TypeError(msg);
     }

--- a/src/PlainResult/flatten.ts
+++ b/src/PlainResult/flatten.ts
@@ -1,14 +1,14 @@
 import { Result } from './Result';
 import { andThenForResult } from './andThen';
 
-function flatten<T, E>(input: Result<T, E>): Result<T, E> {
+function flatten<T, TError>(input: Result<T, TError>): Result<T, TError> {
     return input;
 }
 
 /**
  * Converts from `Result<Result<T, E>, E>` to `Result<T, E>`
  */
-export function flattenForResult<T, E>(input: Result<Result<T, E>, E>): Result<T, E> {
-    const r: Result<T, E> = andThenForResult(input, flatten);
+export function flattenForResult<T, TError>(input: Result<Result<T, TError>, TError>): Result<T, TError> {
+    const r: Result<T, TError> = andThenForResult(input, flatten);
     return r;
 }

--- a/src/PlainResult/map.ts
+++ b/src/PlainResult/map.ts
@@ -2,14 +2,14 @@ import { MapFn } from '../shared/Function';
 import { Result, Err, createOk } from './Result';
 
 /**
- *  Maps a `Result<T, E>` to `Result<U, E>` by applying a _selector_ function
- *  to an contained `Ok(T)` value, leaving an `Err(E)` value untouched.
+ *  Maps a `Result<T, TError>` to `Result<U, TError>` by applying a _fn_ function
+ *  to an contained `Ok(T)` value, leaving an `Err(TError)` value untouched.
  *
  *  This function can be used to compose the results of two functions.
  */
-export function mapForResult<T, U, TError>(src: Result<T, TError>, selector: MapFn<T, U>): Result<U, TError> {
+export function mapForResult<T, U, TError>(src: Result<T, TError>, fn: MapFn<T, U>): Result<U, TError> {
     if (src.ok) {
-        const r: U = selector(src.val);
+        const r: U = fn(src.val);
         return createOk(r);
     }
     else {

--- a/src/PlainResult/map.ts
+++ b/src/PlainResult/map.ts
@@ -7,13 +7,13 @@ import { Result, Err, createOk } from './Result';
  *
  *  This function can be used to compose the results of two functions.
  */
-export function mapForResult<T, U, E>(src: Result<T, E>, selector: MapFn<T, U>): Result<U, E> {
+export function mapForResult<T, U, TError>(src: Result<T, TError>, selector: MapFn<T, U>): Result<U, TError> {
     if (src.ok) {
         const r: U = selector(src.val);
         return createOk(r);
     }
     else {
-        const s: Err<E> = src;
+        const s: Err<TError> = src;
         return s;
     }
 }

--- a/src/PlainResult/mapErr.ts
+++ b/src/PlainResult/mapErr.ts
@@ -2,14 +2,14 @@ import { MapFn } from '../shared/Function';
 import { Result, createErr } from './Result';
 
 /**
- *  Maps a `Result<T, TError>` to `Result<T, TAnotherError>` by applying a _selector_ function `mapFn<TError, TAnotherError>`
+ *  Maps a `Result<T, TError>` to `Result<T, TAnotherError>` by applying a _fn_ `mapFn<TError, TAnotherError>`
  *  to an contained `Err(TError)` value, leaving an `Ok(T)` value untouched.
  *
  *  This function can be used to pass through a successful result while handling an error.
  */
-export function mapErrForResult<T, TError, TAnotherError>(src: Result<T, TError>, selector: MapFn<TError, TAnotherError>): Result<T, TAnotherError> {
+export function mapErrForResult<T, TError, TAnotherError>(src: Result<T, TError>, fn: MapFn<TError, TAnotherError>): Result<T, TAnotherError> {
     if (!src.ok) {
-        const r: TAnotherError = selector(src.err);
+        const r: TAnotherError = fn(src.err);
         return createErr<TAnotherError>(r);
     }
     else {

--- a/src/PlainResult/mapErr.ts
+++ b/src/PlainResult/mapErr.ts
@@ -2,15 +2,15 @@ import { MapFn } from '../shared/Function';
 import { Result, createErr } from './Result';
 
 /**
- *  Maps a `Result<T, E>` to `Result<T, F>` by applying a _selector_ function `mapFn<E, F>`
- *  to an contained `Err(E)` value, leaving an `Ok(T)` value untouched.
+ *  Maps a `Result<T, TError>` to `Result<T, TAnotherError>` by applying a _selector_ function `mapFn<TError, TAnotherError>`
+ *  to an contained `Err(TError)` value, leaving an `Ok(T)` value untouched.
  *
  *  This function can be used to pass through a successful result while handling an error.
  */
-export function mapErrForResult<T, E, F>(src: Result<T, E>, selector: MapFn<E, F>): Result<T, F> {
+export function mapErrForResult<T, TError, TAnotherError>(src: Result<T, TError>, selector: MapFn<TError, TAnotherError>): Result<T, TAnotherError> {
     if (!src.ok) {
-        const r: F = selector(src.err);
-        return createErr<F>(r);
+        const r: TAnotherError = selector(src.err);
+        return createErr<TAnotherError>(r);
     }
     else {
         return src;

--- a/src/PlainResult/mapOr.ts
+++ b/src/PlainResult/mapOr.ts
@@ -7,7 +7,7 @@ import { MapFn } from '../shared/Function';
  *
  *  Basically, this operation is a combination `map()` and `unwrapOr()`.
  */
-export function mapOrForResult<T, E, U>(src: Result<T, E>, def: U, selector: MapFn<T, U>): U {
+export function mapOrForResult<T, TError, U>(src: Result<T, TError>, def: U, selector: MapFn<T, U>): U {
     let r: U;
     if (src.ok) {
         r = selector(src.val);

--- a/src/PlainResult/mapOr.ts
+++ b/src/PlainResult/mapOr.ts
@@ -2,15 +2,15 @@ import { Result } from './Result';
 import { MapFn } from '../shared/Function';
 
 /**
- *  Return the result of _selector_ with using _src_ as an argument for it if _src_ is `Ok(T)`.
+ *  Return the result of _fn_ with using _src_ as an argument for it if _src_ is `Ok(T)`.
  *  Otherwise, return _def_.
  *
  *  Basically, this operation is a combination `map()` and `unwrapOr()`.
  */
-export function mapOrForResult<T, TError, U>(src: Result<T, TError>, def: U, selector: MapFn<T, U>): U {
+export function mapOrForResult<T, TError, U>(src: Result<T, TError>, def: U, fn: MapFn<T, U>): U {
     let r: U;
     if (src.ok) {
-        r = selector(src.val);
+        r = fn(src.val);
     }
     else {
         r = def;

--- a/src/PlainResult/mapOrElse.ts
+++ b/src/PlainResult/mapOrElse.ts
@@ -2,11 +2,11 @@ import { MapFn, RecoveryWithErrorFn } from '../shared/Function';
 import { Result } from './Result';
 
 /**
- *  Maps a `Result<T, E>` to `U` by applying _selector_ to a contained `Ok(T)` value in _src_,
- *  or a _fallback_ function to a contained `Err(E)` value in _src_.
+ *  Maps a `Result<T, TError>` to `U` by applying _selector_ to a contained `Ok(T)` value in _src_,
+ *  or a _fallback_ function to a contained `Err(TError)` value in _src_.
  *  This function can be used to unpack a successful result while handling an error.
  */
-export function mapOrElseForResult<T, E, U>(src: Result<T, E>, fallback: RecoveryWithErrorFn<E, U>, selector: MapFn<T, U>): U {
+export function mapOrElseForResult<T, TError, U>(src: Result<T, TError>, fallback: RecoveryWithErrorFn<TError, U>, selector: MapFn<T, U>): U {
     if (src.ok) {
         const r: U = selector(src.val);
         return r;

--- a/src/PlainResult/mapOrElse.ts
+++ b/src/PlainResult/mapOrElse.ts
@@ -2,13 +2,13 @@ import { MapFn, RecoveryWithErrorFn } from '../shared/Function';
 import { Result } from './Result';
 
 /**
- *  Maps a `Result<T, TError>` to `U` by applying _selector_ to a contained `Ok(T)` value in _src_,
+ *  Maps a `Result<T, TError>` to `U` by applying _fn_ to a contained `Ok(T)` value in _src_,
  *  or a _fallback_ function to a contained `Err(TError)` value in _src_.
  *  This function can be used to unpack a successful result while handling an error.
  */
-export function mapOrElseForResult<T, TError, U>(src: Result<T, TError>, fallback: RecoveryWithErrorFn<TError, U>, selector: MapFn<T, U>): U {
+export function mapOrElseForResult<T, TError, U>(src: Result<T, TError>, fallback: RecoveryWithErrorFn<TError, U>, fn: MapFn<T, U>): U {
     if (src.ok) {
-        const r: U = selector(src.val);
+        const r: U = fn(src.val);
         return r;
     }
     else {

--- a/src/PlainResult/or.ts
+++ b/src/PlainResult/or.ts
@@ -4,6 +4,6 @@ import { Result } from './Result';
  *  Return _a_ if _a_ is `Ok(T)`.
  *  Otherwise, return _b_.
  */
-export function orForResult<T, E, F>(a: Result<T, E>, b: Result<T, F>): Result<T, F> {
+export function orForResult<T, TError, TAnotherError>(a: Result<T, TError>, b: Result<T, TAnotherError>): Result<T, TAnotherError> {
     return a.ok ? a : b;
 }

--- a/src/PlainResult/orElse.ts
+++ b/src/PlainResult/orElse.ts
@@ -1,14 +1,14 @@
 import { MapFn } from '../shared/Function';
 import { Result } from './Result';
 
-export type FlatmapErrFn<T, E, F> = MapFn<E, Result<T, F>>;
+export type FlatmapErrFn<T, TError, TAnotherError> = MapFn<TError, Result<T, TAnotherError>>;
 
 /**
  *  Calls _errSelector_  and return its returned value
- *  if the result is `Err(E)`, otherwise returns the `Ok(T)` value of self.
+ *  if the result is `Err(TError)`, otherwise returns the `Ok(T)` value of self.
  *  This function can be used for control flow based on result values.
  */
-export function orElseForResult<T, E, F>(a: Result<T, E>, errSelector: FlatmapErrFn<T, E, F>): Result<T, F> {
+export function orElseForResult<T, TError, TAnotherError>(a: Result<T, TError>, errSelector: FlatmapErrFn<T, TError, TAnotherError>): Result<T, TAnotherError> {
     if (a.ok) {
         return a;
     }

--- a/src/PlainResult/tap.ts
+++ b/src/PlainResult/tap.ts
@@ -11,7 +11,7 @@ function noop<T>(_v: T) {}
  *    If you don't have to do it, you should not mutate the inner value.
  *    if-else statement might be sufficient to mutate the inner value instead of calling this function.
  */
-export function tapOk<T, E>(v: Result<T, E>, fn: TapFn<T>): Result<T, E> {
+export function tapOk<T, TError>(v: Result<T, TError>, fn: TapFn<T>): Result<T, TError> {
     return tapBoth(v, fn, noop);
 }
 
@@ -23,7 +23,7 @@ export function tapOk<T, E>(v: Result<T, E>, fn: TapFn<T>): Result<T, E> {
  *    If you don't have to do it, you should not mutate the inner value.
  *    if-else statement might be sufficient to mutate the inner value instead of calling this function.
  */
-export function tapErr<T, E>(v: Result<T, E>, fn: TapFn<E>): Result<T, E> {
+export function tapErr<T, TError>(v: Result<T, TError>, fn: TapFn<TError>): Result<T, TError> {
     return tapBoth(v, noop, fn);
 }
 
@@ -36,7 +36,7 @@ export function tapErr<T, E>(v: Result<T, E>, fn: TapFn<E>): Result<T, E> {
  *    If you don't have to do it, you should not mutate the inner value.
  *    if-else statement might be sufficient to mutate the inner value instead of calling this function.
  */
-export function tapBoth<T, E>(src: Result<T, E>, okFn: TapFn<T>, errFn: TapFn<E>): Result<T, E> {
+export function tapBoth<T, TError>(src: Result<T, TError>, okFn: TapFn<T>, errFn: TapFn<TError>): Result<T, TError> {
     if (src.ok) {
         okFn(src.val);
     }

--- a/src/PlainResult/toOption.ts
+++ b/src/PlainResult/toOption.ts
@@ -5,7 +5,7 @@ import { Result } from './Result';
  *  Convert to `Some(T)` if _v_ is `Ok(T)`.
  *  Otherwise, return `None`.
  */
-export function toOptionFromOk<T, E>(v: Result<T, E>): Option<T> {
+export function toOptionFromOk<T, TError>(v: Result<T, TError>): Option<T> {
     if (v.ok) {
         return createSome<T>(v.val);
     }
@@ -15,12 +15,12 @@ export function toOptionFromOk<T, E>(v: Result<T, E>): Option<T> {
 }
 
 /**
- *  Convert to `Some(E)` if _v_ is `Err(E)`.
+ *  Convert to `Some(TError)` if _v_ is `Err(TError)`.
  *  Otherwise, return `None`.
  */
-export function toOptionFromErr<T, E>(v: Result<T, E>): Option<E> {
+export function toOptionFromErr<T, TError>(v: Result<T, TError>): Option<TError> {
     if (!v.ok) {
-        return createSome<E>(v.err);
+        return createSome<TError>(v.err);
     }
     else {
         return createNone();

--- a/src/PlainResult/transpose.ts
+++ b/src/PlainResult/transpose.ts
@@ -8,11 +8,11 @@ import { Result, Ok, Err, isErr, createOk, createErr } from './Result';
  *  - `Ok(None)` -> `None`
  *  - `Err(e)` -> `Some(Err(e))`
  */
-export function transposeForResult<T, E>(self: Result<Option<T>, E>): Option<Result<T, E>> {
+export function transposeForResult<T, TError>(self: Result<Option<T>, TError>): Option<Result<T, TError>> {
     if (isErr(self)) {
-        const e: E = self.err;
-        const newErr: Err<E> = createErr(e);
-        const r: Some<Err<E>> = createSome<Err<E>>(newErr);
+        const e: TError = self.err;
+        const newErr: Err<TError> = createErr(e);
+        const r: Some<Err<TError>> = createSome<Err<TError>>(newErr);
         return r;
     }
 

--- a/src/PlainResult/unwrap.ts
+++ b/src/PlainResult/unwrap.ts
@@ -7,16 +7,16 @@ import { Result } from './Result';
  *  @throws {TypeError}
  *      Throws if the self is a `Err`.
  */
-export function unwrapFromResult<T, E>(v: Result<T, E>): T | never {
+export function unwrapFromResult<T, TError>(v: Result<T, TError>): T | never {
     return expectIsOk(v, 'called with `Err`');
 }
 
 /**
- *  Return the inner `E` of a `Err(E)`.
+ *  Return the inner `TError` of a `Err(TError)`.
  *
  *  @throws {TypeError}
  *      Throws if the self is a `Ok`.
  */
-export function unwrapErrFromResult<T, E>(v: Result<T, E>): E | never {
+export function unwrapErrFromResult<T, TError>(v: Result<T, TError>): TError | never {
     return expectIsErr(v, 'called with `Ok`');
 }

--- a/src/PlainResult/unwrapOr.ts
+++ b/src/PlainResult/unwrapOr.ts
@@ -2,8 +2,8 @@ import { Result } from './Result';
 
 /**
  *  Unwraps a result _v_, returns the content of an `Ok(T)`.
- *  If the value is an `Err(E)` then return _def_.
+ *  If the value is an `Err(TError)` then return _def_.
  */
-export function unwrapOrFromResult<T, E>(v: Result<T, E>, def: T): T {
+export function unwrapOrFromResult<T, TError>(v: Result<T, TError>, def: T): T {
     return v.ok ? v.val : def;
 }

--- a/src/PlainResult/unwrapOrElse.ts
+++ b/src/PlainResult/unwrapOrElse.ts
@@ -3,8 +3,8 @@ import { Result } from './Result';
 
 /**
  *  Unwraps a result _v_, returns the content of an `Ok(T)`.
- *  If the value is an `Err(E)` then it calls `def` with its value.
+ *  If the value is an `Err(TError)` then it calls `def` with its value.
  */
-export function unwrapOrElseFromResult<T, E>(v: Result<T, E>, def: RecoveryWithErrorFn<E, T>): T {
+export function unwrapOrElseFromResult<T, TError>(v: Result<T, TError>, def: RecoveryWithErrorFn<TError, T>): T {
     return v.ok ? v.val : def(v.err);
 }

--- a/src/shared/Function.ts
+++ b/src/shared/Function.ts
@@ -1,5 +1,5 @@
-export type MapFn<T, U> = (v: T) => U;
+export type MapFn<T, TResult> = (v: T) => TResult;
 export type RecoveryFn<T> = () => T;
-export type RecoveryWithErrorFn<E, T> = (e: E) => T;
+export type RecoveryWithErrorFn<TError, T> = (e: TError) => T;
 export type TapFn<T> = (v: T) => void;
 export type FilterFn<T> = (v: T) => boolean;


### PR DESCRIPTION
## Motivation

* I'd like to remove hacks for ESLint which was introduced in https://github.com/karen-irc/option-t/pull/669
* I'd like to clarify meanings of type parameters. 

## Details

* Change `Result<T, E>` -> `Result<T, TError>`
* Change `<T, U, E, F>` -> `<T, U, TError, TAnotherError>`

## Questions

### Is this a breaking change?

* No. I suspect this would not be breaking change.
* TypeScrpt does not have [_Associated types_](https://doc.rust-lang.org/stable/rust-by-example/generics/assoc_items/types.html#associated-types). A user project will not specify these type parameters directly.
* If user project comment like "we use barfooType for `E` in `Err(E)`", then the comment will be confusable.
* But I don't think this is a problem. It does not change a semantics and all comments often lies.

## Unresolved Questions

1. Should we change `T` in `Result<T, TError>`  to more clear form?
   1. No change.
   1. `Result<TValue, TError>`
   1. `Result<TSuccess, TError>`
   1. something else.
2. If we change `T` to `Result<T, TError>`, how should we change `<T, U>`?
   1. No change. (`T` is also not changed)
   1. `U` -> `TOutput`
   1. `U` -> `TAnother***`
       * I think this is redundant.
   1. `U` -> `TResult`
       * [C# use this style](https://docs.microsoft.com/en-us/dotnet/api/system.func-2?view=netcore-3.1).
       * But I don't like this because this is confusable.
            * Would you like to talk like that "you should change the naming of the return type `TResult` of `barfoo()` of `PlainResult` to `SomethingElse`"?
            *  It's nightmare