### PR TITLE
Suppress warnings in __tests__

### DIFF
--- a/__tests__/.eslintrc.js
+++ b/__tests__/.eslintrc.js
@@ -3,19 +3,13 @@
 
 'use strict'; // eslint-disable-line strict
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require('path');
 
 // ESLint Configuration Files enables to include comments.
 // http://eslint.org/docs/configuring/#comments-in-configuration-files
 module.exports = {
-    'extends': [
-        '../tools/eslint/eslintrc_typescript.js',
-    ],
-
     'parserOptions': {
         'sourceType': 'module',
-        'project': path.resolve(__dirname, '../tsconfig_eslint.json'),
     },
 
     'env': {
@@ -25,6 +19,25 @@ module.exports = {
     },
 
     'rules': {
-        '@typescript-eslint/no-magic-numbers': 'off',
-    }
+        'no-magic-numbers': 'off',
+    },
+
+    'overrides': [
+        {
+            'files': ['*.ts'],
+
+            'extends': [
+                '../tools/eslint/eslintrc_typescript.js',
+            ],
+
+            'parserOptions': {
+                'sourceType': 'module',
+                'project': path.resolve(__dirname, '../tsconfig_eslint.json'),
+            },
+
+            'rules': {
+                '@typescript-eslint/no-magic-numbers': 'off',
+            },
+        },
+    ],
 };


### PR DESCRIPTION
Mysteriously, the previous settins causes many warnings happens only in CI...
Is this reproducible on Linux? (But I don't have any environments).

I suspect this is caused by using typescript-eslint for JS files.
So I fix it in this change.