### PR TITLE
Upgrade TypeScript compiler to v4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       ignore:
           - dependency-name: typescript
             versions:
-                - ">3.7"
+                - ">=4.1"
 
     - package-ecosystem: github-actions
       directory: "/"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",
     "prettier": "^2.1.1",
-    "typescript": "~3.7.3"
+    "typescript": "^4.0.2"
   },
   "sideEffects": false,
   "typings": "./cjs/index.d.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,10 +4745,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~3.7.3:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This is required to migrate __tests__/ to TypeScript by ts-migrate https://github.com/karen-irc/option-t/pull/715