### PR TITLE
Omit unused generic type parameters from unwrap/unwrapErr/unwrapOr for PlainResult

### DIFF
--- a/src/PlainResult/unwrap.ts
+++ b/src/PlainResult/unwrap.ts
@@ -7,7 +7,7 @@ import { Result } from './Result';
  *  @throws {TypeError}
  *      Throws if the self is a `Err`.
  */
-export function unwrapFromResult<T, E>(v: Result<T, E>): T | never {
+export function unwrapFromResult<T>(v: Result<T, unknown>): T | never {
     return expectIsOk(v, 'called with `Err`');
 }
 
@@ -17,6 +17,6 @@ export function unwrapFromResult<T, E>(v: Result<T, E>): T | never {
  *  @throws {TypeError}
  *      Throws if the self is a `Ok`.
  */
-export function unwrapErrFromResult<T, E>(v: Result<T, E>): E | never {
+export function unwrapErrFromResult<E>(v: Result<unknown, E>): E | never {
     return expectIsErr(v, 'called with `Ok`');
 }

--- a/src/PlainResult/unwrapOr.ts
+++ b/src/PlainResult/unwrapOr.ts
@@ -4,6 +4,6 @@ import { Result } from './Result';
  *  Unwraps a result _v_, returns the content of an `Ok(T)`.
  *  If the value is an `Err(E)` then return _def_.
  */
-export function unwrapOrFromResult<T, E>(v: Result<T, E>, def: T): T {
+export function unwrapOrFromResult<T>(v: Result<T, unknown>, def: T): T {
     return v.ok ? v.val : def;
 }


### PR DESCRIPTION
- `unknown` is _top type_. We can assign any of types to it.
- From TS 3.5, [Generic type parameters are implicitly constrained to `unknown`](https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/). Thus the behavior is not changed after this patch. This changes to more explicit way.
- Ideally, we wanted to use `never` type. But `never` type is _bottom type_. So we cannot assign `Ok<T>` to `Ok<never>`.
- Overloading has some problem with intellisense. It's not nice for productivity and this kind of troubles are happened in old days of rxjs.

Fix #791