### PR TITLE
Remove 'main' field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "24.0.0",
   "description": "Option type implementation whose APIs are inspired by Rust's `Option<T>`.",
   "type": "commonjs",
-  "main": "./cjs/index.js",
   "files": [
     "CHANGELOG.md",
     "cjs/",

--- a/tools/package_json_rewriter/transformer/add_exports_field/main.mjs
+++ b/tools/package_json_rewriter/transformer/add_exports_field/main.mjs
@@ -1,4 +1,3 @@
-import * as assert from 'assert';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 
@@ -16,15 +15,6 @@ const THIS_DIRNAME = dirname(THIS_FILENAME);
 
 const BASE_DIR = THIS_DIRNAME;
 
-function addMainFieldFromPackageJSON(targetObject, manifestInfo) {
-    const mainPath = manifestInfo.main;
-    assert.strictEqual(typeof mainPath, 'string', `package.json's 'main' field is not string`);
-    assert.ok(mainPath.startsWith('./'), `package.json's 'main' field should start with ./`);
-
-    // eslint-disable-next-line no-param-reassign
-    targetObject['.'] = mainPath;
-}
-
 export async function addExportsFields(json) {
     const o = Object.create(null);
 
@@ -33,10 +23,6 @@ export async function addExportsFields(json) {
 
     const publicApiList = await loadPublicAPIDefinitions(BASE_DIR, '../../../public_api.mjs');
     await addPublicAPIToExportsFields(o, publicApiList);
-
-    // For the future, we may have a chance to remove this
-    // when https://github.com/nodejs/node/issues/32107/ has been fixed.
-    addMainFieldFromPackageJSON(o, json);
 
     // eslint-disable-next-line no-param-reassign
     json.exports = o;

--- a/tools/package_json_rewriter/transformer/add_exports_field/public_api.mjs
+++ b/tools/package_json_rewriter/transformer/add_exports_field/public_api.mjs
@@ -11,6 +11,12 @@ class ExportEntity {
     }
 
     key() {
+        const key = this._key;
+        // For `main` field
+        if (key === '.') {
+            return key;
+        }
+
         const k = `./${this._key}`;
         return k;
     }

--- a/tools/public_api.mjs
+++ b/tools/public_api.mjs
@@ -1,4 +1,9 @@
 export default {
+    '.': {
+        'path': 'index',
+        'exports': []
+    },
+
     'Maybe': {
         'path': 'Maybe/index',
         'exports': [


### PR DESCRIPTION
We use 'exports' field so we don't have to keep this.

Fix https://github.com/karen-irc/option-t/issues/803