### PR TITLE
Add the flag to switch to expose lib/

### DIFF
--- a/tools/package_export_tester.mjs
+++ b/tools/package_export_tester.mjs
@@ -13,6 +13,8 @@ const THIS_DIRNAME = dirname(THIS_FILENAME);
 const BASE_DIR = THIS_DIRNAME;
 const PACKAGE_NAME = 'option-t';
 
+const SHOULD_EXPOSE_LIB = true;
+
 function loadCJS(file) {
     const modulepath = (file === '.') ? PACKAGE_NAME : `${PACKAGE_NAME}/${file}`;
     const mod = require(modulepath);
@@ -45,10 +47,16 @@ async function testSpecialCaseLoadIndexJS(installedPackageJSON) {
         'PlainResult',
         'Undefinable',
     ];
-    const NODE_MODULE_RESOLUTION_SPECIAL_CASE_CJS = [
+    let NODE_MODULE_RESOLUTION_SPECIAL_CASE_CJS = [
         ...DIR_SUBPATH.map((path) => `cjs/${path}`),
-        ...DIR_SUBPATH.map((path) => `lib/${path}`),
     ];
+
+    if (SHOULD_EXPOSE_LIB) {
+        NODE_MODULE_RESOLUTION_SPECIAL_CASE_CJS = [
+            ...NODE_MODULE_RESOLUTION_SPECIAL_CASE_CJS,
+            ...DIR_SUBPATH.map((path) => `lib/${path}`),
+        ];
+    }
 
     // `require()` can load `./index.js` with a parent directry name.
     // This behavior is not supported by Node.js' ESM implementation.
@@ -94,7 +102,7 @@ function testPackageJSONHasExportsEntry(pkgObj, entryName, entryFileName) {
         else if (file.startsWith('esm/')) {
             esmFileList.push(file);
         }
-        else if (file.startsWith('lib/')) {
+        else if (SHOULD_EXPOSE_LIB && file.startsWith('lib/')) {
             libFileList.push(file);
         }
         else {

--- a/tools/package_json_rewriter/transformer/add_exports_field/compatibility.mjs
+++ b/tools/package_json_rewriter/transformer/add_exports_field/compatibility.mjs
@@ -2,10 +2,18 @@ import * as assert from 'assert';
 
 import { loadJSON } from '../../json.mjs';
 
+const SHOULD_EXPOSE_LIB = true;
+
 function filterJSDir(histricalPathInfo) {
     assert.ok(Array.isArray(histricalPathInfo));
 
     const jsDir = histricalPathInfo.filter((filepath) => {
+        if (!SHOULD_EXPOSE_LIB) {
+            if ((/^lib\//u).test(filepath)) {
+                return false;
+            }
+        }
+
         if (!(/^(cjs|esm|lib)\//u).test(filepath)) {
             return false;
         }
@@ -33,7 +41,7 @@ export function addHistoricalPathToExportsFields(o, histricalJSPathList) {
         o[filepath] = filepath;
 
         // Use cjs for lib/
-        if (filepath.startsWith('./lib/') && filepath.endsWith('.mjs')) {
+        if (SHOULD_EXPOSE_LIB && filepath.startsWith('./lib/') && filepath.endsWith('.mjs')) {
             continue;
         }
 
@@ -62,5 +70,7 @@ export function addHistoricalPathToExportsFields(o, histricalJSPathList) {
     handleSpecialCaseOfNodeModuleResolution(DIR_SUBPATH.map((path) => `cjs/${path}`), 'js');
     handleSpecialCaseOfNodeModuleResolution(DIR_SUBPATH.map((path) => `esm/${path}`), 'mjs');
     // Our defult is still commonjs. For lib/, we should use `.js`.
-    handleSpecialCaseOfNodeModuleResolution(DIR_SUBPATH.map((path) => `lib/${path}`), 'js');
+    if (SHOULD_EXPOSE_LIB) {
+        handleSpecialCaseOfNodeModuleResolution(DIR_SUBPATH.map((path) => `lib/${path}`), 'js');
+    }
 }


### PR DESCRIPTION
- If we disable this flag, we would not export lib/.
- But the published package would contains files under lib/.
    - It should be separated issue to make the release easy

## Related Issue

- https://github.com/karen-irc/option-t/issues/808