### PR TITLE
Move Changelog to GitHub's release page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Changelogs are moved to [GitHub's release page](https://github.com/karen-irc/option-t/releases).
+If you see more details, please compare each tags in that pages.
+
+Please see [CHANGELOG_OLD](./CHANGELOG_OLD.md) if you need old changelogs.

--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -1,10 +1,6 @@
 # Changelog
 
-If you see more details, please compare each tags by [GitHub's release page](https://github.com/karen-irc/option-t/releases).
-
-## x.y.z
-
-[See more details](https://github.com//karen-irc/option-t/compare/v24.1.1...master).
+Changelogs are moved to [GitHub's release page](https://github.com/karen-irc/option-t/releases).
 
 ## 24.1.1
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ cp_docs: clean_dist
 
 .PHONY: cp_changelog
 cp_changelog: clean_dist
-	$(NPM_BIN)/cpx '$(CURDIR)/CHANGELOG.md' $(DIST_DIR)
+	$(NPM_BIN)/cpx '$(CURDIR)/{CHANGELOG.md,CHANGELOG_OLD.md}' $(DIST_DIR)
 
 .PHONY: cp_license
 cp_license: clean_dist

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "commonjs",
   "files": [
     "CHANGELOG.md",
+    "CHANGELOG_OLD.md",
     "cjs/",
     "docs/",
     "esm/",

--- a/tools/pkg_files.json
+++ b/tools/pkg_files.json
@@ -1,5 +1,6 @@
 [
   "CHANGELOG.md",
+  "CHANGELOG_OLD.md",
   "LICENSE.MIT",
   "README.md",
   "cjs/Maybe/ErrorMessage.d.ts",


### PR DESCRIPTION
It's tired effort to maintain changelogs and GitHub release page on releasing each versions.

We moved to publish to npm semi-automatically on creating github release.

- https://github.com/karen-irc/option-t/pull/853
- https://github.com/karen-irc/option-t/pull/852
- https://github.com/karen-irc/option-t/pull/851

So this intend to stop to update a changelog as a file.