### PR TITLE
Remove needless steps from publish to npm action.

### DIFF
--- a/.github/workflows/publish_package_to_npm.yml
+++ b/.github/workflows/publish_package_to_npm.yml
@@ -12,7 +12,6 @@ jobs:
             - run: yarn install
             - run: make clean
             - run: make prepublish -j
-            - run: make copy_npmrc_to_project_root
             - run: make publish -j
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This task will be executed by `make publish`
This followup https://github.com/karen-irc/option-t/pull/853