### PR TITLE
Use ES6 partially for classic wrapper objects

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -1,5 +1,4 @@
 /* eslint-enable valid-jsdoc */
-/* eslint-disable func-name-matching */
 
 /**
  *  @deprecated
@@ -16,20 +15,22 @@
  *
  *  The usecase example is a `React.PropTypes.
  */
-export function OptionBase(ok, val) {
-    /**
-     *  @private
-     *  @type   {boolean}
-     */
-    this.ok = ok;
+export class OptionBase {
+    constructor(ok, val) {
+        /**
+         *  @private
+         *  @type   {boolean}
+         */
+        this.ok = ok;
 
-    /**
-     *  @private
-     *  @type   {T|undefined}
-     */
-    this.val = val;
+        /**
+         *  @private
+         *  @type   {T|undefined}
+         */
+        this.val = val;
 
-    Object.seal(this);
+        Object.seal(this);
+    }
 }
 OptionBase.prototype = Object.freeze({
     /**
@@ -59,7 +60,7 @@ OptionBase.prototype = Object.freeze({
      *  @throws {TypeError}
      *      Throws if the self value equals `None`.
      */
-    unwrap: function OptionTUnwrap() {
+    unwrap() {
         if (!this.ok) {
             throw new TypeError('called `unwrap()` on a `None` value');
         }
@@ -75,7 +76,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {T} def
      *  @return {T}
      */
-    unwrapOr: function OptionTUnwrapOr(def) {
+    unwrapOr(def) {
         return this.ok ? this.val : def;
     },
 
@@ -87,7 +88,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {function(): T} fn
      *  @return {T}
      */
-    unwrapOrElse: function OptionTUnwrapOrElse(fn) {
+    unwrapOrElse(fn) {
         return this.ok ? this.val : fn();
     },
 
@@ -102,7 +103,7 @@ OptionBase.prototype = Object.freeze({
      *      Throws a custom error with provided `msg`
      *      if the self value equals `None`.
      */
-    expect: function OptionTExpect(msg) {
+    expect(msg) {
         if (!this.ok) {
             throw new TypeError(msg);
         }
@@ -118,7 +119,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {function(T):U}    fn
      *  @return {!Option<U>}
      */
-    map: function OptionTMap(fn) {
+    map(fn) {
         if (!this.ok) {
             // cheat to escape from a needless allocation.
             return this;
@@ -138,7 +139,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {function(T): !Option<U>}    fn
      *  @return {!Option<U>}
      */
-    flatMap: function OptionTFlatMap(fn) {
+    flatMap(fn) {
         if (!this.ok) {
             // cheat to escape from a needless allocation.
             return this;
@@ -162,7 +163,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {function(T):U} fn
      *  @return {U}
      */
-    mapOr: function OptionTMapOr(def, fn) {
+    mapOr(def, fn) {
         if (this.ok) {
             return fn(this.val);
         } else {
@@ -179,7 +180,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {function(T):U} fn
      *  @return {U}
      */
-    mapOrElse: function OptionTMapOrElse(defFn, fn) {
+    mapOrElse(defFn, fn) {
         if (this.ok) {
             return fn(this.val);
         } else {
@@ -195,7 +196,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {!Option<U>} optb
      *  @return {!Option<U>}
      */
-    and: function OptionTAnd(optb) {
+    and(optb) {
         return this.ok ? optb : this;
     },
 
@@ -207,7 +208,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {function(T): !Option<U>}    fn
      *  @return {!Option<U>}
      */
-    andThen: function OptionTAndThen(fn) {
+    andThen(fn) {
         return this.flatMap(fn);
     },
 
@@ -219,7 +220,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {!Option<T>} optb
      *  @return {!Option<T>}
      */
-    or: function OptionTOr(optb) {
+    or(optb) {
         return this.ok ? this : optb;
     },
 
@@ -232,7 +233,7 @@ OptionBase.prototype = Object.freeze({
      *  @param  {function(): !Option<T>} fn
      *  @return {!Option<T>}
      */
-    orElse: function OptionTOr(fn) {
+    orElse(fn) {
         if (this.ok) {
             return this;
         } else {
@@ -253,7 +254,7 @@ OptionBase.prototype = Object.freeze({
      *      This would be called with the inner value if self is `Some<T>`.
      *  @return {void}
      */
-    drop: function OptionTDrop(destructor) {
+    drop(destructor) {
         if (this.ok && typeof destructor === 'function') {
             destructor(this.val);
         }
@@ -265,7 +266,7 @@ OptionBase.prototype = Object.freeze({
     /**
      *  @return {*}
      */
-    toJSON: function OptionTtoJSON() {
+    toJSON() {
         return {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             is_some: this.ok,

--- a/src/Result.js
+++ b/src/Result.js
@@ -1,7 +1,6 @@
 import { createSome, createNone } from './Option';
 
 /* eslint-enable valid-jsdoc */
-/* eslint-disable func-name-matching */
 
 /**
  *  @deprecated
@@ -19,26 +18,25 @@ import { createSome, createNone } from './Option';
  *
  *  The usecase example is a `React.PropTypes`.
  */
-export function ResultBase(ok, val, err) {
-    /**
-     *  @private
-     *  @type   {boolean}
-     */
-    this._isOk = ok;
-
-    /**
-     *  @private
-     *  @type   {T}
-     */
-    this._v = val;
-
-    /**
-     *  @private
-     *  @type   {E}
-     */
-    this._e = err;
-
-    Object.seal(this);
+export class ResultBase {
+    constructor(ok, val, err) {
+        /**
+         *  @private
+         *  @type   {boolean}
+         */
+        this._isOk = ok;
+        /**
+         *  @private
+         *  @type   {T}
+         */
+        this._v = val;
+        /**
+         *  @private
+         *  @type   {E}
+         */
+        this._e = err;
+        Object.seal(this);
+    }
 }
 ResultBase.prototype = Object.freeze({
     /**
@@ -46,7 +44,7 @@ ResultBase.prototype = Object.freeze({
      *
      *  @return {boolean}
      */
-    isOk: function ResultBaseIsOk() {
+    isOk() {
         return this._isOk;
     },
 
@@ -55,7 +53,7 @@ ResultBase.prototype = Object.freeze({
      *
      *  @return {boolean}
      */
-    isErr: function ResultBaseIsErr() {
+    isErr() {
         return !this._isOk;
     },
 
@@ -66,7 +64,7 @@ ResultBase.prototype = Object.freeze({
      *
      *  @return {!OptionT<T>}
      */
-    ok: function ResultBaseOk() {
+    ok() {
         if (this._isOk) {
             return createSome(this._v);
         } else {
@@ -81,7 +79,7 @@ ResultBase.prototype = Object.freeze({
      *
      *  @return {!OptionT<E>}
      */
-    err: function ResultBaseErr() {
+    err() {
         if (!this._isOk) {
             return createSome(this._e);
         } else {
@@ -99,7 +97,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {!function(T):U}    op
      *  @return {!Result<U, E>}
      */
-    map: function ResultBaseMap(op) {
+    map(op) {
         if (!this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
@@ -120,7 +118,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {!function(T):U}    selector
      *  @return {U}
      */
-    mapOrElse: function ResultBaseMapOrResult(fallback, selector) {
+    mapOrElse(fallback, selector) {
         if (!this._isOk) {
             const r = fallback(this._e);
             return r;
@@ -140,7 +138,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {!function(E):F}    op
      *  @return {!Result<T, F>}
      */
-    mapErr: function ResultBaseMapErr(op) {
+    mapErr(op) {
         if (this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
@@ -158,7 +156,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {!Result<U, E>} res
      *  @return {!Result<U, E>}
      */
-    and: function ResultBaseAnd(res) {
+    and(res) {
         if (this._isOk) {
             return res;
         } else {
@@ -175,7 +173,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {!function(T):!Result<U, E>} op
      *  @return {!Result<U, E>}
      */
-    andThen: function ResultBaseAndThen(op) {
+    andThen(op) {
         if (!this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
@@ -197,7 +195,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {!Result<T, F>} res
      *  @return {!Result<T, F>}
      */
-    or: function ResultBaseOr(res) {
+    or(res) {
         if (this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
@@ -214,7 +212,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {!function(E):!Result<T, F>} op
      *  @return {!Result<T, F>}
      */
-    orElse: function ResultBaseOrElse(op) {
+    orElse(op) {
         if (this._isOk) {
             // cheat to escape from a needless allocation.
             return this;
@@ -237,7 +235,7 @@ ResultBase.prototype = Object.freeze({
      *  @throws {TypeError}
      *      Throws if the self is a `Err`.
      */
-    unwrap: function ResultBaseUnwrap() {
+    unwrap() {
         return this.expect('called `unwrap()` on a `Err` value');
     },
 
@@ -249,7 +247,7 @@ ResultBase.prototype = Object.freeze({
      *  @throws {TypeError}
      *      Throws if the self is a `Ok`.
      */
-    unwrapErr: function ResultBaseUnwrapErr() {
+    unwrapErr() {
         if (this._isOk) {
             throw new TypeError('called `unwrapErr()` on a `Ok` value');
         } else {
@@ -263,7 +261,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {T} optb
      *  @return {T}
      */
-    unwrapOr: function ResultBaseUnwrapOr(optb) {
+    unwrapOr(optb) {
         if (this._isOk) {
             return this._v;
         } else {
@@ -278,7 +276,7 @@ ResultBase.prototype = Object.freeze({
      *  @param  {!function(E):T}    op
      *  @return {T}
      */
-    unwrapOrElse: function ResultBaseUnwrapOrElse(op) {
+    unwrapOrElse(op) {
         if (this._isOk) {
             return this._v;
         }
@@ -296,7 +294,7 @@ ResultBase.prototype = Object.freeze({
      *  @throws {TypeError}
      *      Throws the passed `message` if the self is a `Err`.
      */
-    expect: function ResultBaseExpect(message) {
+    expect(message) {
         if (this._isOk) {
             return this._v;
         } else {
@@ -314,7 +312,7 @@ ResultBase.prototype = Object.freeze({
      *      This would be called with the inner value if self is `Err<E>`.
      *  @return {void}
      */
-    drop: function ResultBaseDrop(destructor, errDestructor) {
+    drop(destructor, errDestructor) {
         if (this._isOk) {
             if (typeof destructor === 'function') {
                 destructor(this._v);

--- a/tools/babel/babelconfig.mjs
+++ b/tools/babel/babelconfig.mjs
@@ -11,7 +11,7 @@ export const babelEnvPresetConfig = {
         'node': '8',
     },
     'spec': false,
-    'loose': false,
+    'loose': true,
     'debug': false,
     'useBuiltIns':false,
     'shippedProposals': false,


### PR DESCRIPTION
- For long term maintainability, we'd like to migrate these code to ES6 code base.
- By this change, we use babel's loose transform to reduce the result code size.
- By this change, their member functions are renamed. If user code base has a bad code which depends on stack trace, this will break them.