### PR TITLE
Mark legacy APIs as deperecated

### DIFF
--- a/src/Option.d.ts
+++ b/src/Option.d.ts
@@ -1,6 +1,15 @@
 import { MapFn, RecoveryFn, TapFn } from './shared/Function';
 
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 export type FlatmapFn<T, U> = MapFn<T, Option<U>>;
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 export type MayRecoveryFn<T> = RecoveryFn<Option<T>>;
 
 interface Optionable<T> {
@@ -225,5 +234,14 @@ interface None<T> extends Optionable<T> {
  */
 export type Option<T> = Some<T> | None<T>;
 
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 export declare function createSome<T>(val: T): Some<T>;
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 export declare function createNone<T>(): None<T>;

--- a/src/Result.d.ts
+++ b/src/Result.d.ts
@@ -1,7 +1,16 @@
 import { Option, Some, None } from './Option';
 import { MapFn, RecoveryWithErrorFn, TapFn } from './shared/Function';
 
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 export type FlatmapOkFn<T, U, E> = MapFn<T, Result<U, E>>;
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 export type FlatmapErrFn<T, E, F> = MapFn<E, Result<T, F>>;
 
 interface Resultable<T, E> {
@@ -203,5 +212,14 @@ interface Err<T, E> extends Resultable<T, E> {
  */
 export type Result<T, E> = Ok<T, E> | Err<T, E>;
 
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 export declare function createOk<T, E>(val: T): Ok<T, E>;
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 export declare function createErr<T, E>(err: E): Err<T, E>;


### PR DESCRIPTION
We had marked these for js files in https://github.com/karen-irc/option-t/pull/462. But we forgot to do them for d.ts....