### PR TITLE
Revive constructors of classic wrapper objects for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ yarn add option-t --save
         * [`Result<T, E>` (`{ ok: true; val: T } | { ok: false; err: E; }`)](./src/PlainResult/)
 * [Wrapper objects](./docs/wrapper_objects.md) ([__*deprecated*__](https://github.com/karen-irc/option-t/issues/459)).
     * [`ClassicOption<T>`](./src/ClassOption/ClassicOption.d.ts)
-    * [`ClassicOption<T, E>`](./src/ClassResult/ClassicResult.d.ts)
+    * [`ClassicResult<T, E>`](./src/ClassResult/ClassicResult.d.ts)
 
 
 ### Utility functions for some types.

--- a/__tests__/ClassOption/inheritance.test.mjs
+++ b/__tests__/ClassOption/inheritance.test.mjs
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { createSome, createNone, OptionBase } from '../../__dist/esm/Option.mjs';
+import { createSome, createNone, OptionBase, Some, None } from '../../__dist/esm/Option.mjs';
 
 test('`Some<T>`', function (t) {
     const option = createSome(1);
@@ -10,6 +10,18 @@ test('`Some<T>`', function (t) {
 test('`None`', function (t) {
     const option = createNone();
     t.is(option instanceof OptionBase, true);
+});
+
+test('`Some<T> by Constructor`', function (t) {
+    const option = new Some(1);
+    t.true(option instanceof OptionBase, 'is instanceof OptionBase');
+    t.false(option instanceof Some, 'is not instanceof Some');
+});
+
+test('`None by Constructor`', function (t) {
+    const option = new None();
+    t.is(option instanceof OptionBase, true);
+    t.false(option instanceof None, 'is not instanceof None');
 });
 
 test('prototype should be frozen', (t) => {

--- a/__tests__/ClassOption/initialize.test.mjs
+++ b/__tests__/ClassOption/initialize.test.mjs
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { createSome, createNone } from '../../__dist/esm/Option.mjs';
+import { createSome, createNone, Some, None } from '../../__dist/esm/Option.mjs';
 
 import {
     primitiveVal,
@@ -19,22 +19,51 @@ const param = primitiveVal
     .concat(undefinedVal);
 param.forEach(function (value) {
     const type = typeof value;
-    const label = 'Some(T): type: ' + type + ', value: `' + String(value) + '`';
 
-    test(label, function (t) {
-        const option = createSome(value);
+    {
+        const label = 'Some(T): type: ' + type + ', value: `' + String(value) + '`';
 
-        t.is(option.isSome, true, 'should be `Some<T>`');
-        t.is(option.isNone, false, 'should not be `None`');
-        t.is(option.isSome, true, '`isSome` should be expected');
-        t.is(option.isNone, false, '`isNone` should be expected');
-        t.is(option.toJSON().value, value, 'the wrapped value should be expected');
-        t.true(Object.isSealed(option), 'the object should be sealed');
-    });
+        test(label, function (t) {
+            const option = createSome(value);
+
+            t.is(option.isSome, true, 'should be `Some<T>`');
+            t.is(option.isNone, false, 'should not be `None`');
+            t.is(option.isSome, true, '`isSome` should be expected');
+            t.is(option.isNone, false, '`isNone` should be expected');
+            t.is(option.toJSON().value, value, 'the wrapped value should be expected');
+            t.true(Object.isSealed(option), 'the object should be sealed');
+        });
+    }
+
+    {
+        const label = 'Some(T): type: ' + type + ', value: `' + String(value) + ' by Constructor`';
+
+        test(label, function (t) {
+            const option = new Some(value);
+
+            t.is(option.isSome, true, 'should be `Some<T>`');
+            t.is(option.isNone, false, 'should not be `None`');
+            t.is(option.isSome, true, '`isSome` should be expected');
+            t.is(option.isNone, false, '`isNone` should be expected');
+            t.is(option.toJSON().value, value, 'the wrapped value should be expected');
+            t.true(Object.isSealed(option), 'the object should be sealed');
+        });
+    }
 });
 
 test('`None`', function (t) {
     const option = createNone();
+
+    t.is(option.isNone, true, 'should be `None`');
+    t.is(option.isSome, false, 'should not be `Some<T>`');
+    t.is(option.isSome, false, '`isSome` should be expected');
+    t.is(option.isNone, true, '`isNone` should be expected');
+    t.is(option.toJSON().value, undefined, '`value` should be expected');
+    t.true(Object.isSealed(option), 'the object should be sealed');
+});
+
+test('`None by constructor`', function (t) {
+    const option = new None();
 
     t.is(option.isNone, true, 'should be `None`');
     t.is(option.isSome, false, 'should not be `Some<T>`');

--- a/__tests__/ClassOption/type_definition.ts
+++ b/__tests__/ClassOption/type_definition.ts
@@ -1,11 +1,12 @@
 // XXX:
 // The type definitions for '--moduleResolution node' is a ES6 format,
 // So it would test it by importing it simply.
-import { Option, OptionBase, createSome, createNone } from '../../__dist/esm/Option.mjs';
+import { Option, OptionBase, createSome, createNone, Some, None } from '../../__dist/esm/Option';
 
 // `Some<T>`
 (function () {
     var option: Option<number> = createSome(1);
+    option = new Some<number>(1);
     option = createSome<number>(1);
     var isSome: boolean = option.isSome;
     var isNone: boolean = option.isNone;
@@ -51,6 +52,7 @@ import { Option, OptionBase, createSome, createNone } from '../../__dist/esm/Opt
 // `None<T>`
 (function () {
     var option: Option<number> = createNone<number>();
+    option = new None<number>();
     option = createNone<number>();
     var isSome: boolean = option.isSome;
     var isNone: boolean = option.isNone;

--- a/__tests__/ClassResult/inheritance.test.mjs
+++ b/__tests__/ClassResult/inheritance.test.mjs
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { createOk, createErr, ResultBase } from '../../__dist/esm/Result.mjs';
+import { createOk, createErr, ResultBase, Ok, Err } from '../../__dist/esm/Result.mjs';
 
 test('Ok<T> should be instanceof `ResultBase`', (t) => {
     const result = createOk(1);
@@ -10,6 +10,26 @@ test('Ok<T> should be instanceof `ResultBase`', (t) => {
 test('Err<E> should be instanceof `ResultBase`', (t) => {
     const result = createErr(2);
     t.true(result instanceof ResultBase);
+});
+
+test('Ok<T> by Constructor should be instanceof `ResultBase`', (t) => {
+    const result = new Ok(1);
+    t.true(result instanceof ResultBase);
+});
+
+test('Err<E> by Constructor should be instanceof `ResultBase`', (t) => {
+    const result = new Err(2);
+    t.true(result instanceof ResultBase);
+});
+
+test('Ok<T> by Constructor should NOT be instanceof `Ok`', (t) => {
+    const result = new Ok(1);
+    t.false(result instanceof Ok);
+});
+
+test('Err<E> by Constructor should NOT be instanceof `Err`', (t) => {
+    const result = new Err(2);
+    t.false(result instanceof Err);
 });
 
 test('prototype should be frozen', (t) => {

--- a/__tests__/ClassResult/initialize.test.mjs
+++ b/__tests__/ClassResult/initialize.test.mjs
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { createOk, createErr } from '../../__dist/esm/Result.mjs';
+import { createOk, createErr, Ok, Err } from '../../__dist/esm/Result.mjs';
 
 import {
     primitiveVal,
@@ -35,9 +35,39 @@ for (const value of param) {
 
 for (const value of param) {
     const type = typeof value;
+    const label = 'OK<T>: type: ' + type + ', value: `' + String(value) + ' by Constructor`';
+    test(label, (t) => {
+        const result = new Ok(value);
+
+        t.is(Object.isSealed(result), true, 'should be sealed');
+        t.is(result.isOk(), true, 'should be `Ok<T>`');
+        t.is(result.isErr(), false, 'should not be `Err<E>`');
+        t.is(result.isOk(), true, '`isOk` should be expected');
+        t.is(result.isErr(), false, '`isErr` should be expected');
+        t.true(Object.isSealed(result), 'the object should be sealed');
+    });
+}
+
+for (const value of param) {
+    const type = typeof value;
     const label = 'Err<E>: type: ' + type + ', value: `' + String(value) + '`';
     test(label, (t) => {
         const result = createErr(value);
+
+        t.is(Object.isSealed(result), true, 'should be sealed');
+        t.is(result.isOk(), false, 'should be `Err<E>`');
+        t.is(result.isErr(), true, 'should not be `Ok<T>`');
+        t.is(result.isOk(), false, '`isOk` should be expected');
+        t.is(result.isErr(), true, '`isErr` should be expected');
+        t.true(Object.isSealed(result), 'the object should be sealed');
+    });
+}
+
+for (const value of param) {
+    const type = typeof value;
+    const label = 'Err<E>: type: ' + type + ', value: `' + String(value) + ' by Constuctor`';
+    test(label, (t) => {
+        const result = new Err(value);
 
         t.is(Object.isSealed(result), true, 'should be sealed');
         t.is(result.isOk(), false, 'should be `Err<E>`');

--- a/__tests__/ClassResult/type_definition_es6.ts
+++ b/__tests__/ClassResult/type_definition_es6.ts
@@ -4,11 +4,12 @@
 // The type definitions for '--moduleResolution node' is a ES6 format,
 // So it would test it by importing it simply.
 import { Option } from '../../__dist/esm/Option';
-import { Result, ResultBase, createOk, createErr } from '../../__dist/esm/Result';
+import { Result, ResultBase, createOk, createErr, Ok, Err } from '../../__dist/esm/Result';
 
 //  Ok<T>
 (function () {
     let result: Result<number, void> = createOk<number, void>(1);
+    result = new Ok<number, void>(1);
     result = createOk<number, void>(1);
 
     const isOk: boolean = result.isOk();
@@ -59,6 +60,7 @@ import { Result, ResultBase, createOk, createErr } from '../../__dist/esm/Result
 //  Err<E>
 (function () {
     let result: Result<number, void> = createErr<number, void>(undefined);
+    result = new Err<number, void>(undefined);
     result = createErr<number, void>(undefined);
 
     const isOk: boolean = result.isOk();

--- a/src/ClassOption/ClassicOption.d.ts
+++ b/src/ClassOption/ClassicOption.d.ts
@@ -2,42 +2,33 @@ import type { MapFn, RecoveryFn, TapFn } from '../shared/Function';
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export type ClassicFlatmapFn<T, U> = MapFn<T, ClassicOption<U>>;
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export type ClassicMayRecoveryFn<T> = RecoveryFn<ClassicOption<T>>;
 
+/**
+ *  @deprecated
+ *      We keep this only for backward compatibility.
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 interface ClassicOptionable<T> {
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return whether the self is `Some<T>` or not.
      */
     readonly isSome: boolean;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return whether the self is `None` or not.
      */
     readonly isNone: boolean;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the inner `T` of a `Some<T>`.
      *
      *  @throws {Error}
@@ -46,10 +37,6 @@ interface ClassicOptionable<T> {
     unwrap(): T | never;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the contained value or a default value `def`.
      *
      *  @param  def
@@ -58,10 +45,6 @@ interface ClassicOptionable<T> {
     unwrapOr(def: T): T;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the contained value or compute it from a closure `fn`.
      *
      *  @param fn
@@ -70,10 +53,6 @@ interface ClassicOptionable<T> {
     unwrapOrElse(fn: RecoveryFn<T>): T;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the inner `T` of a `Some<T>`.
      *
      *  @param  msg
@@ -85,10 +64,6 @@ interface ClassicOptionable<T> {
     expect(msg: string): T | never;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Map an `Option<T>` to `Option<U>` by applying a function to the contained value.
      *
      *  @param  fn
@@ -98,10 +73,6 @@ interface ClassicOptionable<T> {
     map<U>(fn: MapFn<T, U>): ClassicOption<U>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return `None` if the self is `None`,
      *  otherwise call `fn` with the wrapped value and return the result.
      *
@@ -112,10 +83,6 @@ interface ClassicOptionable<T> {
     flatMap<U>(fn: ClassicFlatmapFn<T, U>): ClassicOption<U>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Apply a function `fn` to the contained value or return a default `def`.
      *
      *  @param  def
@@ -127,10 +94,6 @@ interface ClassicOptionable<T> {
     mapOr<U>(def: U, fn: MapFn<T, U>): U;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Apply a function `fn` to the contained value or produce a default result by `defFn`.
      *
      *  @param  defFn
@@ -142,10 +105,6 @@ interface ClassicOptionable<T> {
     mapOrElse<U>(def: RecoveryFn<U>, fn: MapFn<T, U>): U;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the passed value if the self is `Some<T>`,
      *  otherwise return `None`.
      *
@@ -155,10 +114,6 @@ interface ClassicOptionable<T> {
     and<U>(optb: ClassicOption<U>): ClassicOption<U>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  The alias of `Option<T>.flatMap()`.
      *
      *  @param  fn
@@ -166,10 +121,6 @@ interface ClassicOptionable<T> {
     andThen<U>(fn: ClassicFlatmapFn<T, U>): ClassicOption<U>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the self if it contains a value, otherwise return `optb`.
      *
      *  @param  optb
@@ -178,10 +129,6 @@ interface ClassicOptionable<T> {
     or(optb: ClassicOption<T>): ClassicOption<T>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the self if it contains a value,
      *  otherwise call `fn` and returns the result.
      *
@@ -191,10 +138,6 @@ interface ClassicOptionable<T> {
     orElse(fn: ClassicMayRecoveryFn<T>): ClassicOption<T>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Finalize the self.
      *  After this is called, the object's behavior is not defined.
      *
@@ -208,7 +151,6 @@ interface ClassicOptionable<T> {
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  The base object of `Some<T>` and `None<T>`.
@@ -256,63 +198,32 @@ export abstract class ClassicOptionBase<T> implements ClassicOptionable<T> {
     toJSON(): { is_some: boolean; value: T | undefined };
 }
 
+/**
+ *  @deprecated
+ *      We keep this only for backward compatibility.
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 interface ClassicSome<T> extends ClassicOptionable<T> {
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     readonly isSome: true;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     readonly isNone: false;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     unwrap(): T;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     expect(msg: string): T;
-}
-
-interface ClassicNone<T> extends ClassicOptionable<T> {
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    readonly isSome: false;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    readonly isNone: true;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    unwrap(): never;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    expect(msg: string): never;
 }
 
 /**
  *  @deprecated
  *      We keep this only for backward compatibility.
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+interface ClassicNone<T> extends ClassicOptionable<T> {
+    readonly isSome: false;
+    readonly isNone: true;
+    unwrap(): never;
+    expect(msg: string): never;
+}
+
+/**
+ *  @deprecated
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  The Option/Maybe type interface whose APIs are inspired
@@ -340,14 +251,12 @@ export type ClassicOption<T> = ClassicSome<T> | ClassicNone<T>;
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export declare function createClassicSome<T>(val: T): ClassicSome<T>;
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export declare function createClassicNone<T>(): ClassicNone<T>;

--- a/src/ClassOption/ClassicOption.d.ts
+++ b/src/ClassOption/ClassicOption.d.ts
@@ -260,3 +260,17 @@ export declare function createClassicSome<T>(val: T): ClassicSome<T>;
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export declare function createClassicNone<T>(): ClassicNone<T>;
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export declare const ClassicSomeConstructor: new <T>(val: T) => ClassicSome<T>;
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export declare const ClassicNoneConstructor: new <T>() => ClassicNone<T>;

--- a/src/ClassOption/ClassicOption.js
+++ b/src/ClassOption/ClassicOption.js
@@ -2,7 +2,6 @@
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  @constructor
@@ -35,10 +34,6 @@ export class ClassicOptionBase {
 }
 ClassicOptionBase.prototype = Object.freeze({
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return whether this is `Some<T>` or not.
      *
      *  @return {boolean}
@@ -48,10 +43,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return whether this is `None` or not.
      *
      *  @return {boolean}
@@ -61,10 +52,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns the inner `T` of a `Some<T>`.
      *
      *  @template   T
@@ -82,10 +69,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns the contained value or a default value `def`.
      *
      *  @template   T
@@ -98,14 +81,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns the contained value or computes it from a closure `fn`.
      *
      *  @template   T
@@ -118,10 +93,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns the inner `T` of a `Some<T>`.
      *
      *  @template   T
@@ -141,10 +112,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Maps an `Option<T>` to `Option<U>` by applying a function to a contained value.
      *
      *  @template   T, U
@@ -164,10 +131,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns `None` if the self is `None`,
      *  otherwise calls `fn` with the wrapped value and returns the result.
      *
@@ -192,10 +155,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Applies a function `fn` to the contained value or returns a default `def`.
      *
      *  @template   T, U
@@ -213,10 +172,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Applies a function `fn` to the contained value or computes a default result by `defFn`.
      *
      *  @template   T, U
@@ -234,10 +189,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns `None` if the self is `None`, otherwise returns `optb`.
      *
      *  @template   U
@@ -250,10 +201,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  The alias of `Option<T>.flatMap()`.
      *
      *  @template   T, U
@@ -266,10 +213,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns the self if it contains a value, otherwise returns `optb`.
      *
      *  @template   T
@@ -282,10 +225,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns the self if it contains a value,
      *  otherwise calls `fn` and returns the result.
      *
@@ -308,10 +247,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Finalize the self.
      *  After this is called, the object's behavior is not defined.
      *
@@ -329,10 +264,6 @@ ClassicOptionBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  @return {*}
      */
     toJSON() {
@@ -346,7 +277,6 @@ ClassicOptionBase.prototype = Object.freeze({
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  @template   T
@@ -360,7 +290,6 @@ export function createClassicSome(val) {
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  @template   T

--- a/src/ClassOption/ClassicOption.js
+++ b/src/ClassOption/ClassicOption.js
@@ -299,3 +299,19 @@ export function createClassicNone() {
     const o = new ClassicOptionBase(false, undefined);
     return o;
 }
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+export function ClassicSomeConstructor(val) {
+    return createClassicSome(val);
+}
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+export function ClassicNoneConstructor() {
+    return createClassicNone();
+}

--- a/src/ClassResult/ClassicResult.d.ts
+++ b/src/ClassResult/ClassicResult.d.ts
@@ -239,3 +239,17 @@ export declare function createClassicOk<T, E>(val: T): ClassicOk<T, E>;
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export declare function createClassicErr<T, E>(err: E): ClassicErr<T, E>;
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export declare const ClassicOkConstructor: new <T, E>(val: T) => ClassicOk<T, E>;
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export declare const ClassicErrConstructor: new <T, E>(err: E) => ClassicErr<T, E>;

--- a/src/ClassResult/ClassicResult.d.ts
+++ b/src/ClassResult/ClassicResult.d.ts
@@ -3,42 +3,33 @@ import type { MapFn, RecoveryWithErrorFn, TapFn } from '../shared/Function';
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export type ClassicFlatmapOkFn<T, U, E> = MapFn<T, ClassicResult<U, E>>;
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export type ClassicFlatmapErrFn<T, E, F> = MapFn<E, ClassicResult<T, F>>;
 
+/**
+ *  @deprecated
+ *      We keep this only for backward compatibility.
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 interface ClassicResultable<T, E> {
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns true if the result is `Ok`.
      */
     isOk(): this is ClassicOk<T, E>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns true if the result is `Err`.
      */
     isErr(): this is ClassicErr<T, E>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Converts from `Result<T, E>` to `Option<T>`.
      *  If the self is `Ok`, returns `Some<T>`.
      *  Otherwise, returns `None<T>`.
@@ -46,10 +37,6 @@ interface ClassicResultable<T, E> {
     ok(): ClassicOption<T>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Converts from `Result<T, E>` to `Option<E>`.
      *  If the self is `Err`, returns `Some<E>`.
      *  Otherwise, returns `None<E>`.
@@ -57,10 +44,6 @@ interface ClassicResultable<T, E> {
     err(): ClassicOption<E>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Maps a `Result<T, E>` to `Result<U, E>` by applying a function `mapFn<T, U>`
      *  to an contained `Ok` value, leaving an `Err` value untouched.
      *
@@ -69,10 +52,6 @@ interface ClassicResultable<T, E> {
     map<U>(op: MapFn<T, U>): ClassicResult<U, E>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Maps a `Result<T, E>` to `U` by applying a function to a contained `Ok` value,
      *  or a `fallback` function to a contained `Err` value.
      *  This function can be used to unpack a successful result while handling an error.
@@ -80,10 +59,6 @@ interface ClassicResultable<T, E> {
     mapOrElse<U>(fallback: RecoveryWithErrorFn<E, U>, selector: MapFn<T, U>): U;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Maps a `Result<T, E>` to `Result<T, F>` by applying a function `mapFn<E, F>`
      *  to an contained `Err` value, leaving an `Ok` value untouched.
      *
@@ -92,48 +67,28 @@ interface ClassicResultable<T, E> {
     mapErr<F>(op: MapFn<E, F>): ClassicResult<T, F>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns `res` if the result is `Ok`, otherwise returns the `Err` value of self.
      */
     and<U>(res: ClassicResult<U, E>): ClassicResult<U, E>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Calls `op` if the result is `Ok`, otherwise returns the `Err` value of self.
      *  This function can be used for control flow based on result values.
      */
     andThen<U>(op: ClassicFlatmapOkFn<T, U, E>): ClassicResult<U, E>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns `res` if the result is `Err`, otherwise returns the `Ok` value of self.
      */
     or<F>(res: ClassicResult<T, F>): ClassicResult<T, F>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Calls `op` if the result is `Err`, otherwise returns the `Ok` value of self.
      *  This function can be used for control flow based on result values.
      */
     orElse<F>(op: ClassicFlatmapErrFn<T, E, F>): ClassicResult<T, F>;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the inner `T` of a `Ok(T)`.
      *
      *  @throws {Error}
@@ -142,10 +97,6 @@ interface ClassicResultable<T, E> {
     unwrap(): T | never;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the inner `E` of a `Err(E)`.
      *
      *  @throws {Error}
@@ -154,29 +105,17 @@ interface ClassicResultable<T, E> {
     unwrapErr(): E | never;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Unwraps a result, return the content of an `Ok`. Else it returns `optb`.
      */
     unwrapOr(optb: T): T;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Unwraps a result, returns the content of an `Ok`.
      *  If the value is an `Err` then it calls `op` with its value.
      */
     unwrapOrElse(op: RecoveryWithErrorFn<E, T>): T;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the inner `T` of a `Ok(T)`.
      *
      *  @throws {Error}
@@ -185,10 +124,6 @@ interface ClassicResultable<T, E> {
     expect(message: string): T | never;
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  The destructor method inspired by Rust's `Drop` trait.
      *  We don't define the object's behavior after calling this.
      *
@@ -202,7 +137,6 @@ interface ClassicResultable<T, E> {
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  * XXX:
@@ -235,85 +169,40 @@ export abstract class ClassicResultBase<T, E> implements ClassicResultable<T, E>
     drop(destructor?: TapFn<T>, errDestructor?: TapFn<E>): void;
 }
 
+/**
+ *  @deprecated
+ *      We keep this only for backward compatibility.
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
 interface ClassicOk<T, E> extends ClassicResultable<T, E> {
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     ok(): Some<T>;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     err(): None<E>;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     unwrap(): T;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     unwrapErr(): never;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     unwrapOr(optb: T): T;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
     expect(message: string): T;
-}
-
-// XXX:
-// This class intend to represent the container of some error type `E`.
-// So we don't define this as `Error`'s subclass
-// or don't restrict type parameter `E`'s upper bound to `Error`.
-interface ClassicErr<T, E> extends ClassicResultable<T, E> {
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    ok(): None<T>;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    err(): Some<E>;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    unwrap(): never;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    unwrapErr(): E;
-    /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     */
-    expect(message: string): never;
 }
 
 /**
  *  @deprecated
  *      We keep this only for backward compatibility.
+ *      See https://github.com/karen-irc/option-t/issues/459
+ *
+ *  XXX:
+ *  This class intend to represent the container of some error type `E`.
+ *  So we don't define this as `Error`'s subclass
+ *  or don't restrict type parameter `E`'s upper bound to `Error`.
+ */
+interface ClassicErr<T, E> extends ClassicResultable<T, E> {
+    ok(): None<T>;
+    err(): Some<E>;
+    unwrap(): never;
+    unwrapErr(): E;
+    expect(message: string): never;
+}
+
+/**
+ *  @deprecated
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  The Result/Either type interface whose APIs are inspired
@@ -341,14 +230,12 @@ export type ClassicResult<T, E> = ClassicOk<T, E> | ClassicErr<T, E>;
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export declare function createClassicOk<T, E>(val: T): ClassicOk<T, E>;
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
 export declare function createClassicErr<T, E>(err: E): ClassicErr<T, E>;

--- a/src/ClassResult/ClassicResult.js
+++ b/src/ClassResult/ClassicResult.js
@@ -4,7 +4,6 @@ import { createClassicSome, createClassicNone } from '../ClassOption/ClassicOpti
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  @constructor
@@ -41,10 +40,6 @@ export class ClassicResultBase {
 }
 ClassicResultBase.prototype = Object.freeze({
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns true if the result is `Ok`.
      *
      *  @return {boolean}
@@ -54,10 +49,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns true if the result is `Err`.
      *
      *  @return {boolean}
@@ -67,10 +58,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Converts from `Result<T, E>` to `Option<T>`.
      *  If the self is `Ok`, returns `Some<T>`.
      *  Otherwise, returns `None<T>`.
@@ -86,10 +73,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Converts from `Result<T, E>` to `Option<E>`.
      *  If the self is `Err`, returns `Some<E>`.
      *  Otherwise, returns `None<E>`.
@@ -105,10 +88,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Maps a `Result<T, E>` to `Result<U, E>` by applying a function `mapFn<T, U>`
      *  to an contained `Ok` value, leaving an `Err` value untouched.
      *
@@ -130,10 +109,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Maps a `Result<T, E>` to `U` by applying a function to a contained `Ok` value,
      *  or a `fallback` function to a contained `Err` value.
      *  This function can be used to unpack a successful result while handling an error.
@@ -154,10 +129,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Maps a `Result<T, E>` to `Result<T, F>` by applying a function `mapFn<E, F>`
      *  to an contained `Err` value, leaving an `Ok` value untouched.
      *
@@ -179,10 +150,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns `res` if the result is `Ok`, otherwise returns the `Err` value of self.
      *
      *  @template   U
@@ -199,10 +166,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Calls `op` if the result is `Ok`, otherwise returns the `Err` value of self.
      *  This function can be used for control flow based on result values.
      *
@@ -226,10 +189,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Returns `res` if the result is `Err`, otherwise returns the `Ok` value of self.
      *
      *  @template   F
@@ -246,10 +205,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Calls `op` if the result is `Err`, otherwise returns the `Ok` value of self.
      *  This function can be used for control flow based on result values.
      *
@@ -273,10 +228,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the inner `T` of a `Ok(T)`.
      *
      *  @return {T}
@@ -289,10 +240,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the inner `E` of a `Err(E)`.
      *
      *  @return {E}
@@ -309,10 +256,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Unwraps a result, return the content of an `Ok`. Else it returns `optb`.
      *
      *  @param  {T} optb
@@ -327,10 +270,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Unwraps a result, returns the content of an `Ok`.
      *  If the value is an `Err` then it calls `op` with its value.
      *
@@ -347,10 +286,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  Return the inner `T` of a `Ok(T)`.
      *
      *  @param  {string}    message
@@ -368,10 +303,6 @@ ClassicResultBase.prototype = Object.freeze({
     },
 
     /**
-     *  @deprecated
-     *      We keep this only for backward compatibility.
-     *      See https://github.com/karen-irc/option-t/issues/459
-     *
      *  The destructor method inspired by Rust's `Drop` trait.
      *  We don't define the object's behavior after calling this.
      *
@@ -399,7 +330,6 @@ ClassicResultBase.prototype = Object.freeze({
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  @template   T, E
@@ -413,7 +343,6 @@ export function createClassicOk(v) {
 
 /**
  *  @deprecated
- *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  *
  *  @template   T, E

--- a/src/ClassResult/ClassicResult.js
+++ b/src/ClassResult/ClassicResult.js
@@ -353,3 +353,19 @@ export function createClassicErr(e) {
     const o = new ClassicResultBase(false, undefined, e);
     return o;
 }
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+export function ClassicOkConstructor(val) {
+    return createClassicOk(val);
+}
+
+/**
+ *  @deprecated
+ *      See https://github.com/karen-irc/option-t/issues/459
+ */
+export function ClassicErrConstructor(e) {
+    return createClassicErr(e);
+}

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -10,6 +10,8 @@ export {
     ClassicOption as Option,
     createClassicSome as createSome,
     createClassicNone as createNone,
+    ClassicSomeConstructor as Some,
+    ClassicNoneConstructor as None,
 } from './ClassOption/ClassicOption';
 
 export { compatToClassicOption, compatToPlainOption } from './ClassOption/compat';

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -10,6 +10,8 @@ export {
     ClassicResult as Result,
     createClassicOk as createOk,
     createClassicErr as createErr,
+    ClassicOkConstructor as Ok,
+    ClassicErrConstructor as Err,
 } from './ClassResult/ClassicResult';
 
 export { compatToClassicResult, compatToPlainResult } from './ClassResult/compat';


### PR DESCRIPTION
## Motivation

I got a feedback that:

- some projects are still continue to use old version with pinning the old version.
- method chaining style is nice to use.

By these feedback, I revive some removed APIs to allow to migration to the newer version.
After some internal re-layout and some evolving typescript compiler, we can add these legacy APIs without invading intellisense.

## Detailed

####  Revert almost `@deprecated` marking,

- We continue to recommend to not use classic wrapper objects.
- But their method chain should not be marked as deprecated for people that like method chain style.

#### Revive constructors of classic wrapper objects removed by #364 for compatibility

After this change, these code pattern will continue to be `false`.

- `option instanceof Some`
- `option instanceof None`
- `option instanceof Ok`
- `option instanceof Err`

## Related Issues

- https://github.com/karen-irc/option-t/pull/364