### PR TITLE
Mark `ok`/`err` export from PlainResult/index as deprecated.

### DIFF
--- a/src/PlainResult/index.ts
+++ b/src/PlainResult/index.ts
@@ -47,7 +47,15 @@ export { transposeForResult as transpose } from './transpose';
 export {
     toOptionFromOk,
     toOptionFromErr,
+    /**
+     *  @deprecated
+     *  Use `toOptionFromOk` instead.
+     */
     toOptionFromOk as ok,
+    /**
+     *  @deprecated
+     *  Use `toOptionFromErr` instead.
+     */
     toOptionFromErr as err,
 } from './toOption';
 export { unwrapFromResult as unwrap, unwrapErrFromResult as unwrapErr } from './unwrap';


### PR DESCRIPTION
We would like to remove these.
In Rust, `Option<T>` is a 1st citizen. So I think it's beneficial to
provide conversions as a short name.

But this is not.
Generally, `null` may be more better choice in JavaScript.
So the time is over to treat these function as special case.