### PR TITLE
unsafeDrop() should release the field and freeze itself.

### DIFF
--- a/__tests__/PlainOption/drop.test.mjs
+++ b/__tests__/PlainOption/drop.test.mjs
@@ -12,8 +12,9 @@ test('unsafeDropForOption() with Some', (t) => {
         v.val = expected;
     });
 
-    t.is(actual.ok, false);
-    t.is(actual.val, expected);
+    t.is(actual.ok, false, 'should be modified');
+    t.is(actual.val, undefined, 'should be released');
+    t.true(Object.isFrozen(actual), 'should be frozen');
 });
 
 test('unsafeDropForOption() with None', (t) => {
@@ -22,5 +23,6 @@ test('unsafeDropForOption() with None', (t) => {
         t.fail('Do not enter this path.');
     });
 
-    t.is(actual.ok, false);
+    t.is(actual.ok, false, 'should not be modified');
+    t.true(Object.isFrozen(actual), 'should be frozen');
 });

--- a/__tests__/PlainResult/drop/test_drop_both.test.mjs
+++ b/__tests__/PlainResult/drop/test_drop_both.test.mjs
@@ -19,8 +19,9 @@ test('with Ok', (t) => {
         }
     );
 
-    t.is(actual.ok, false);
-    t.is(actual.val, expected);
+    t.is(actual.ok, false, 'should be modified');
+    t.is(actual.val, undefined, 'should be released');
+    t.true(Object.isFrozen(actual), 'should be frozen');
 });
 
 test('with Err', (t) => {
@@ -38,6 +39,7 @@ test('with Err', (t) => {
         }
     );
 
-    t.is(actual.ok, true);
-    t.is(actual.err, expected);
+    t.is(actual.ok, true, 'should be modified');
+    t.is(actual.err, undefined, 'should be released');
+    t.true(Object.isFrozen(actual), 'should be frozen');
 });

--- a/__tests__/PlainResult/drop/test_drop_err.test.mjs
+++ b/__tests__/PlainResult/drop/test_drop_err.test.mjs
@@ -11,7 +11,8 @@ test('with Ok', (t) => {
         t.fail('Do not enter this path.');
     });
 
-    t.is(actual.ok, true);
+    t.is(actual.ok, true, 'should not be modified');
+    t.true(Object.isFrozen(actual), 'should be frozen');
 });
 
 test('with Err', (t) => {
@@ -23,6 +24,7 @@ test('with Err', (t) => {
         err.err = expected;
     });
 
-    t.is(actual.ok, true);
-    t.is(actual.err, expected);
+    t.is(actual.ok, true, 'should be modified');
+    t.is(actual.err, undefined, 'should be released');
+    t.true(Object.isFrozen(actual), 'should be frozen');
 });

--- a/__tests__/PlainResult/drop/test_drop_ok.test.mjs
+++ b/__tests__/PlainResult/drop/test_drop_ok.test.mjs
@@ -13,8 +13,9 @@ test('with Ok', (t) => {
         ok.val = expected;
     });
 
-    t.is(actual.ok, false);
-    t.is(actual.val, expected);
+    t.is(actual.ok, false, 'should be modified');
+    t.is(actual.val, undefined, 'should be released');
+    t.true(Object.isFrozen(actual), 'should be frozen');
 });
 
 test('with Err', (t) => {
@@ -24,5 +25,6 @@ test('with Err', (t) => {
         t.fail('Do not enter this path.');
     });
 
-    t.is(actual.ok, false);
+    t.is(actual.ok, false, 'should not be modified');
+    t.true(Object.isFrozen(actual), 'should be frozen');
 });

--- a/src/PlainOption/drop.ts
+++ b/src/PlainOption/drop.ts
@@ -28,5 +28,13 @@ export function unsafeDropForOption<T>(input: Option<T>, mutator: EffectFn<MutSo
     const mutable = asMutOption(input);
     if (mutable.ok) {
         mutator(mutable);
+        mutable.val = undefined as never;
     }
+
+    // By this freezing, if this function is called to the _input_ again,
+    // then this will throw a mutation error on releasing the value.
+    //
+    // We can do similar thing with `WeakSet`.
+    // But we did not choose it way to avoid a side effect to initialize `WeakSet`.
+    Object.freeze(mutable);
 }

--- a/src/PlainResult/drop.ts
+++ b/src/PlainResult/drop.ts
@@ -38,9 +38,18 @@ export function unsafeDropBothForResult<T, E>(
     const mutable = asMutResult(input);
     if (mutable.ok) {
         okMutator(mutable);
+        mutable.val = undefined as never;
     } else {
         errMutator(mutable);
+        mutable.err = undefined as never;
     }
+
+    // By this freezing, if this function is called to the _input_ again,
+    // then this will throw a mutation error on releasing the value.
+    //
+    // We can do similar thing with `WeakSet`.
+    // But we did not choose it way to avoid a side effect to initialize `WeakSet`.
+    Object.freeze(mutable);
 }
 
 /**


### PR DESCRIPTION
This operator is expected to use as a destructor.
So we should do these in them:

-  release the field aggressively
- freeze the object to prevent reuse it.