### PR TITLE
Allow dependabot to update typescript's patch version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,7 @@ updates:
       versioning-strategy: increase
       ignore:
           - dependency-name: typescript
-            versions:
-                - ">=4.2"
+            update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
     - package-ecosystem: github-actions
       directory: "/"


### PR DESCRIPTION
see https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore