### PR TITLE
Fix typo "How to import" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Each of them includes the same directory hierarchy with [under `src`/](./src/).
 
 For example, 
 
-- If your project uses TypeScript `moduleResolution=node12`.
+- If your project uses TypeScript `moduleResolution=node`.
 - If your project uses a classic bundler which does not support `exports` field.
 
 you need to use these paths


### PR DESCRIPTION
tsc with `moduleResolution = node12` supports `exports` in package.json.
This was mistake by https://github.com/karen-irc/option-t/pull/1123