### PR TITLE
Drop Node.js v14 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 14
                     - 16
 
         steps:
@@ -184,7 +183,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 14
                     - 16
 
         steps:
@@ -216,7 +214,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 14
                     - 16
 
         steps:
@@ -248,7 +245,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 14
                     - 16
 
         steps:


### PR DESCRIPTION
v14 enters maintenance LTS. We don't have to support them as Tier 1.

https://nodejs.org/en/about/releases/