### PR TITLE
Use `node:` prefixed path to import Node.js' builtin modules

### DIFF
--- a/tools/cp_files.mjs
+++ b/tools/cp_files.mjs
@@ -1,5 +1,5 @@
-import fs from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import { getAllGlobMatchedFiles } from './glob.mjs';
 import { parseArgs } from './parse_argv.mjs';

--- a/tools/extension_renamer.mjs
+++ b/tools/extension_renamer.mjs
@@ -1,7 +1,7 @@
-import * as assert from 'assert';
-import { promises as fs } from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const FROM_EXTENSION = 'js';
 const TO_EXTENSION = 'mjs';

--- a/tools/generate_import_path_list_markdown.mjs
+++ b/tools/generate_import_path_list_markdown.mjs
@@ -1,7 +1,7 @@
-import * as assert from 'assert';
-import { promises as fs } from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
     generateExposedPathSequence,

--- a/tools/glob.mjs
+++ b/tools/glob.mjs
@@ -1,5 +1,5 @@
-import * as fs from 'fs/promises';
-import * as path from 'path';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 
 import picomatch from 'picomatch';
 

--- a/tools/package_json_rewriter/json.mjs
+++ b/tools/package_json_rewriter/json.mjs
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
-import * as path from 'path';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
 
 async function loadFileAsText(baseDir, filepath) {
     const p = path.resolve(baseDir, filepath);

--- a/tools/package_json_rewriter/main.mjs
+++ b/tools/package_json_rewriter/main.mjs
@@ -1,7 +1,7 @@
-import * as assert from 'assert';
-import { promises as fs } from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { addExportsFields } from './transformer/add_exports_field/main.mjs';
 import { loadJSON } from './json.mjs';

--- a/tools/package_json_rewriter/transformer/add_exports_field/ExportEntry.mjs
+++ b/tools/package_json_rewriter/transformer/add_exports_field/ExportEntry.mjs
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from 'node:assert/strict';
 
 import {
     QuirksLegacyExposedPath

--- a/tools/package_json_rewriter/transformer/add_exports_field/compatibility.mjs
+++ b/tools/package_json_rewriter/transformer/add_exports_field/compatibility.mjs
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from 'node:assert/strict';
 
 import {
     CompatExportEntry,

--- a/tools/package_json_rewriter/transformer/add_exports_field/public_api.mjs
+++ b/tools/package_json_rewriter/transformer/add_exports_field/public_api.mjs
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from 'node:assert/strict';
 
 import { ExportEntry } from './ExportEntry.mjs';
 

--- a/tools/parse_argv.mjs
+++ b/tools/parse_argv.mjs
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from 'node:assert/strict';
 
 function isFlagKey(str) {
     return str.startsWith('--');

--- a/tools/test_esmodule_path_rewrite.mjs
+++ b/tools/test_esmodule_path_rewrite.mjs
@@ -1,7 +1,7 @@
-import * as assert from 'assert';
-import { promises as fs } from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const THIS_FILENAME = fileURLToPath(import.meta.url);
 const THIS_DIRNAME = path.dirname(THIS_FILENAME);

--- a/tools/test_package_contains_expected_all.mjs
+++ b/tools/test_package_contains_expected_all.mjs
@@ -1,7 +1,7 @@
-import * as assert from 'assert';
-import { promises as fs } from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import * as assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const THIS_FILENAME = fileURLToPath(import.meta.url);
 const THIS_DIRNAME = path.dirname(THIS_FILENAME);

--- a/tools/test_package_exports.mjs
+++ b/tools/test_package_exports.mjs
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import { createRequire } from 'module';
+import * as assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
 
 import {
     generateAllExposedPathSequence,


### PR DESCRIPTION
- Depend on https://github.com/karen-irc/option-t/pull/1126