### PR TITLE
Remove all deprecated type alias that are provided alternatives

### DIFF
--- a/src/Maybe/andThen.ts
+++ b/src/Maybe/andThen.ts
@@ -4,11 +4,6 @@ import { Maybe, isNullOrUndefined } from './Maybe';
 export type MaybeTryTransformFn<T, U> = TransformFn<T, Maybe<U>>;
 
 /**
- *  @deprecated Use {@link MaybeTryTransformFn} in the same module.
- */
-export type FlatmapFn<T, U> = MaybeTryTransformFn<T, U>;
-
-/**
  *  Returns `null` or `undefined` if the _input_ is `null` or `undefined`,
  *  otherwise calls _transformer_ with the value and returns the result.
  *

--- a/src/Nullable/andThen.ts
+++ b/src/Nullable/andThen.ts
@@ -4,11 +4,6 @@ import { Nullable, isNull } from './Nullable';
 export type NullableTryTransformFn<T, U> = TransformFn<T, Nullable<U>>;
 
 /**
- *  @deprecated Use {@link NullableTryTransformFn} in the same module.
- */
-export type FlatmapFn<T, U> = NullableTryTransformFn<T, U>;
-
-/**
  *  Returns `null` if the _input_ is `null`,
  *  otherwise calls _transformer_ with the value and returns the result.
  *

--- a/src/Nullable/andThenAsync.ts
+++ b/src/Nullable/andThenAsync.ts
@@ -6,11 +6,6 @@ import { Nullable, isNull } from './Nullable';
 export type NullableAsyncTryTransformFn<T, U> = AsyncTransformFn<T, Nullable<U>>;
 
 /**
- *  @deprecated Use {@link NullableAsyncTryTransformFn} in the same module.
- */
-export type AsyncFlatmapFn<T, U> = NullableAsyncTryTransformFn<T, U>;
-
-/**
  *  Returns `null` if the _input_ is `null`,
  *  otherwise calls _transformer_ with the value and returns the result.
  *

--- a/src/Nullable/orElse.ts
+++ b/src/Nullable/orElse.ts
@@ -4,11 +4,6 @@ import { Nullable } from './Nullable';
 export type NullableTryRecoveryFn<T> = RecoveryFn<Nullable<T>>;
 
 /**
- *  @deprecated Use {@link NullableTryRecoveryFn} in the same module.
- */
-export type MayRecoveryFn<T> = NullableTryRecoveryFn<T>;
-
-/**
  *  Return _input_ as `T` if the passed _input_ is not `null`.
  *  Otherwise, return the result of _recoverer_.
  */

--- a/src/PlainOption/andThen.ts
+++ b/src/PlainOption/andThen.ts
@@ -4,11 +4,6 @@ import { Option } from './Option';
 export type OptionTryTransformFn<T, U> = TransformFn<T, Option<U>>;
 
 /**
- *  @deprecated Use {@link OptionTryTransformFn} in the same module.
- */
-export type FlatmapFn<T, U> = OptionTryTransformFn<T, U>;
-
-/**
  *  Returns `None` if the _input_ is `None`,
  *  otherwise calls _transformer_ with the value and returns the result.
  *

--- a/src/PlainOption/orElse.ts
+++ b/src/PlainOption/orElse.ts
@@ -4,11 +4,6 @@ import { Option } from './Option';
 export type OptionTryRecoveryFn<T> = RecoveryFn<Option<T>>;
 
 /**
- *  @deprecated Use {@link OptionTryRecoveryFn} in the same module.
- */
-export type MayRecoveryFn<T> = OptionTryRecoveryFn<T>;
-
-/**
  *  Return _input_ as `T` if the passed _input_ is `Some(T)`.
  *  Otherwise, return the result of _recoverer_.
  */

--- a/src/PlainResult/andThen.ts
+++ b/src/PlainResult/andThen.ts
@@ -4,11 +4,6 @@ import { Result } from './Result';
 export type ResultTryTransformFn<T, U, E> = TransformFn<T, Result<U, E>>;
 
 /**
- *  @deprecated Use {@link ResultTryTransformFn} in the same module.
- */
-export type FlatmapOkFn<T, U, E> = ResultTryTransformFn<T, U, E>;
-
-/**
  *  Returns `Err(E)` if the _input_ is `Err(E)`,
  *  otherwise calls _transformer_ with the value and returns the result.
  *

--- a/src/PlainResult/andThenAsync.ts
+++ b/src/PlainResult/andThenAsync.ts
@@ -7,11 +7,6 @@ import { unwrapFromResult } from './unwrap';
 export type ResultAsyncTryTransformFn<T, U, E> = AsyncTransformFn<T, Result<U, E>>;
 
 /**
- *  @deprecated Use {@link ResultAsyncTryTransformFn} in the same module.
- */
-export type AsyncFlatmapOkFn<T, U, E> = ResultAsyncTryTransformFn<T, U, E>;
-
-/**
  *  Returns `Promise<Err(E)>` if the _input_ is `Err(E)`,
  *  otherwise calls _transformer_ with the value and returns the result.
  *

--- a/src/PlainResult/orElse.ts
+++ b/src/PlainResult/orElse.ts
@@ -4,11 +4,6 @@ import { Result } from './Result';
 export type ResultTryRecoveryFromErrorFn<T, E, F> = RecoveryFromErrorFn<E, Result<T, F>>;
 
 /**
- *  @deprecated Use {@link ResultTryRecoveryFromErrorFn} in the same module.
- */
-export type FlatmapErrFn<T, E, F> = ResultTryRecoveryFromErrorFn<T, E, F>;
-
-/**
  *  Calls _recoverer_ and return its returned value if _input_ is `Err(E)`,
  *  otherwise returns _input_ as `Ok(T)`.
  *  This function can be used for control flow based on result values.

--- a/src/PlainResult/orElseAsync.ts
+++ b/src/PlainResult/orElseAsync.ts
@@ -7,11 +7,6 @@ import { unwrapErrFromResult } from './unwrap';
 export type ResultAsyncTryRecoveryFromErrorFn<T, E, F> = AsyncRecoveryFromErrorFn<E, Result<T, F>>;
 
 /**
- *  @deprecated Use {@link ResultAsyncTryRecoveryFromErrorFn} in the same module.
- */
-export type AsyncFlatmapErrFn<T, E, F> = ResultAsyncTryRecoveryFromErrorFn<T, E, F>;
-
-/**
  *  Calls _recoverer_ and return its returned value if the result is `Err(E)`,
  *  otherwise returns the `Ok(T)` value of self.
  */

--- a/src/Undefinable/andThen.ts
+++ b/src/Undefinable/andThen.ts
@@ -4,11 +4,6 @@ import { Undefinable, isUndefined } from './Undefinable';
 export type UndefinableTryTransformFn<T, U> = TransformFn<T, Undefinable<U>>;
 
 /**
- *  @deprecated Use {@link UndefinableTryTransformFn} in the same module.
- */
-export type FlatmapFn<T, U> = UndefinableTryTransformFn<T, U>;
-
-/**
  *  Returns `undefined` if the _input_ is `undefined`,
  *  otherwise calls _transformer_ with the value and returns the result.
  *

--- a/src/Undefinable/orElse.ts
+++ b/src/Undefinable/orElse.ts
@@ -4,11 +4,6 @@ import { Undefinable } from './Undefinable';
 export type UndefinableTryRecoveryFn<T> = RecoveryFn<Undefinable<T>>;
 
 /**
- *  @deprecated Use {@link UndefinableTryRecoveryFn} in the same module.
- */
-export type MayRecoveryFn<T> = UndefinableTryRecoveryFn<T>;
-
-/**
  *  Return _input_ as `T` if the passed _input_ is not `undefined`.
  *  Otherwise, return the result of _recoverer_.
  */

--- a/src/shared/Function.ts
+++ b/src/shared/Function.ts
@@ -52,18 +52,3 @@ export type AsyncRecoveryFn<T> = InternalAsyncRecoveryFn<T>;
  *  @deprecated This type is provided for backward compatibility.
  */
 export type AsyncRecoveryFromErrorFn<E, T> = InternalAsyncRecoveryFromErrorFn<E, T>;
-
-/**
- *  @deprecated Use {@link TransformFn} in the same module.
- */
-export type MapFn<T, U> = TransformFn<T, U>;
-
-/**
- *  @deprecated Use {@link RecoveryFromErrorFn} in the same module.
- */
-export type RecoveryWithErrorFn<E, T> = RecoveryFromErrorFn<E, T>;
-
-/**
- *  @deprecated Use {@link EffectFn} in the same module.
- */
-export type TapFn<T> = EffectFn<T>;


### PR DESCRIPTION
These are misintroduced types and provide alternatives for smooth migration. 
We should remove them.