### PR TITLE
Fill unused field for shape stability of `PlainResult<T, E>` type with `null` instead of `undefined`

### DIFF
--- a/__tests__/PlainOption/object_shape.test.mjs
+++ b/__tests__/PlainOption/object_shape.test.mjs
@@ -13,7 +13,7 @@ test('The shape of PlainOption::Some', (t) => {
 test('The shape of PlainOption::None', (t) => {
     const actual = createNone();
     t.false(actual.ok, 'None.ok');
-    t.is(actual.val, undefined, 'None.val');
+    t.is(actual.val, null, 'None.val');
 
     t.true(
         // eslint-disable-next-line no-prototype-builtins

--- a/__tests__/PlainResult/object_shape.test.mjs
+++ b/__tests__/PlainResult/object_shape.test.mjs
@@ -9,7 +9,7 @@ test('The shape of PlainResult::Ok', (t) => {
 
     t.true(actual.ok, 'Ok.ok');
     t.is(actual.val, INNER_VAL, 'Ok.val');
-    t.is(actual.err, undefined, 'Ok.err');
+    t.is(actual.err, null, 'Ok.err');
 
     t.true(
         // eslint-disable-next-line no-prototype-builtins
@@ -24,7 +24,7 @@ test('The shape of PlainResult::Err', (t) => {
     const actual = createErr(INNER_VAL);
 
     t.false(actual.ok, 'Err.ok');
-    t.is(actual.val, undefined, 'Err.val');
+    t.is(actual.val, null, 'Err.val');
 
     t.true(
         // eslint-disable-next-line no-prototype-builtins

--- a/src/PlainOption/Option.ts
+++ b/src/PlainOption/Option.ts
@@ -48,13 +48,12 @@ export interface None {
     // I tested a shape transition for some engines. By their results,
     // I concluded `Some` and `None` should have same properties to make to use the same shape.
     //
-    //  - V8 used an another hidden class if `val` is `number` or others.
+    //  - Modern JSVMs in web engines used a single shape.
+    //      - Inline cache would be monomorphic.
+    //      - I tested JavaScriptCore (for Safari 15.4), SpiderMonkey (for Firefox v99), and V8 9.9.
+    //  - Old V8 used an another hidden class if `val` is `number` or others.
     //      - Inline cache for an object taking this type would be polymorphic.
     //      - But we can assume that it will not be megamorphic by the observation.
-    //  - JavaScriptCore used single structure, not like as V8.
-    //      - Inline cache would be monomorphic.
-    //  - SpiderMonkey, I did not test it. But I assumed it would behave similary with other engines.
-    //      - I had not known how I trace for SM casually...
     //
     // Of course, this decision has some drawbacks for users of this package.
     //
@@ -63,12 +62,11 @@ export interface None {
     //     However, we don't think it is a common operation for user because we provide `is~~()` function
     //     and user will not do their operations generally for a "container" object like this type.
     //
-    //  2. If user will use `const { ok, val }` = None;`, then val will be `undefined`.
-    //     it's will not be a problem because `val` would be `undefined` if this type is `None`.
+    //  2. If user will use `const { ok, val }` = None;`, then val will be `null`.
     //
     // By these reasons, we should not recommend to create this object without this factory function.
     // User can create this object by hand. But it's fragile for the future change. So We should not recommend it.
-    readonly val?: undefined;
+    readonly val?: null;
 }
 
 export function isNone<T>(input: Option<T>): input is None {
@@ -78,7 +76,7 @@ export function isNone<T>(input: Option<T>): input is None {
 export function createNone(): None {
     const r: None = {
         ok: false,
-        val: undefined,
+        val: null,
     };
     return r;
 }

--- a/src/PlainResult/Result.ts
+++ b/src/PlainResult/Result.ts
@@ -32,13 +32,12 @@ export interface Ok<T> {
     // I tested a shape transition for some engines. By their results,
     // I concluded `Ok` and `Err` should have same properties to make to use the same shape.
     //
-    //  - V8 used an another hidden class if `val` is `number` or others.
+    //  - Modern JSVMs in web engines used a single shape.
+    //      - Inline cache would be monomorphic.
+    //      - I tested JavaScriptCore (for Safari 15.4), SpiderMonkey (for Firefox v99), and V8 9.9.
+    //  - Old V8 used an another hidden class if `val` is `number` or others.
     //      - Inline cache for an object taking this type would be polymorphic.
     //      - But we can assume that it will not be megamorphic by the observation.
-    //  - JavaScriptCore used single structure, not like as V8.
-    //      - Inline cache would be monomorphic.
-    //  - SpiderMonkey, I did not test it. But I assumed it would behave similary with other engines.
-    //      - I had not known how I trace for SM casually...
     //
     // Of course, this decision has some drawbacks for users of this package.
     //
@@ -47,13 +46,12 @@ export interface Ok<T> {
     //     However, we don't think it is a common operation for user because we provide `is~~()` function
     //     and user will not do their operations generally for a "container" object like this type.
     //
-    //  2. If user will use `const { ok, err }` = Ok;`, then val will be `undefined`.
-    //     it's will not be a problem because `err` would be `undefined` if this type is `Ok`.
+    //  2. If user will use `const { ok, err }` = Ok;`, then val will be `null`.
     //     We can say same thing for `Err`.
     //
     // By these reasons, we should not recommend to create this object without this factory function.
     // User can create this object by hand. But it's fragile for the future change. So We should not recommend it.
-    readonly err?: undefined;
+    readonly err?: null;
 }
 
 export function isOk<T, E>(input: Result<T, E>): input is Ok<T> {
@@ -64,7 +62,7 @@ export function createOk<T>(val: T): Ok<T> {
     const r: Ok<T> = {
         ok: true,
         val,
-        err: undefined,
+        err: null,
     };
     return r;
 }
@@ -79,13 +77,12 @@ export interface Err<E> {
     // I tested a shape transition for some engines. By their results,
     // I concluded `Ok` and `Err` should have same properties to make to use the same shape.
     //
-    //  - V8 used an another hidden class if `val` is `number` or others.
+    //  - Modern JSVMs in web engines used a single shape.
+    //      - Inline cache would be monomorphic.
+    //      - I tested JavaScriptCore (for Safari 15.4), SpiderMonkey (for Firefox v99), and V8 9.9.
+    //  - Old V8 used an another hidden class if `val` is `number` or others.
     //      - Inline cache for an object taking this type would be polymorphic.
     //      - But we can assume that it will not be megamorphic by the observation.
-    //  - JavaScriptCore used a single structure, not like as V8.
-    //      - Inline cache would be monomorphic.
-    //  - SpiderMonkey, I did not test it. But I assumed it would behave similary with other engines.
-    //      - I had not known how I trace for SM casually...
     //
     // Of course, this decision has some drawbacks for users of this package.
     //
@@ -94,13 +91,12 @@ export interface Err<E> {
     //     However, we don't think it is a common operation for user because we provide `is~~()` function
     //     and user will not do their operations generally for a "container" object like this type.
     //
-    //  2. If user will use `const { ok, err }` = Ok;`, then val will be `undefined`.
-    //     it's will not be a problem because `err` would be `undefined` if this type is `Ok`.
+    //  2. If user will use `const { ok, err }` = Ok;`, then val will be `null`.
     //     We can say same thing for `Err`.
     //
     // By these reasons, we should not recommend to create this object without this factory function.
     // User can create this object by hand. But it's fragile for the future change. So We should not recommend it.
-    readonly val?: undefined;
+    readonly val?: null;
 
     readonly err: E;
 }
@@ -112,8 +108,8 @@ export function isErr<T, E>(input: Result<T, E>): input is Err<E> {
 export function createErr<E>(err: E): Err<E> {
     const r: Err<E> = {
         ok: false,
-        val: undefined,
-        err: err,
+        val: null,
+        err,
     };
     return r;
 }


### PR DESCRIPTION
This is just **Breaking Change**.

## Motivation

With Next.js v12.1, we cannot use `PlainResult` type as the returned type for `getServerSideProps()` by following error.

```
Server Error

Error: Error serializing `.val` returned from `getServerSideProps` in "/path/[bafoo]".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
This error happened while generating the page. Any console logs will be displayed in the terminal window.
```

To avoid this error, an user need to re-implement `createOk`/`createErr`.

Next.js is emerging web development framework and I think it's important for next 3~5 years.

So we should fix them.

## Possible Performance Impact

I confirmed what this change impacts on JSVM's internal shape (SM)/hidden class (V8)/structure (JSC).
I tested JavaScriptCore (for Safari 15.4), SpiderMonkey (for Firefox v99), and V8 9.9.
They are now used a single shape.

So I conclude this would cause a serious performance problem.

### Test code

#### Shared Part

<details>

```javascript
const FILL_VALUE = null;

function ok(val) {
    return { ok, val, err: FILL_VALUE };
}

function err(err) {
    return { ok, val: FILL_VALUE, err };
}

const VALUES = [
    0,
    1,
    -1,
    BigInt(1),
    true,
    false,
    "test",
    null,
    undefined,
    [],
    {},
    function () {},
    Symbol(''),
];

function getTypeof(v) {
    return v === null ? 'null' : typeof v;
}


for (const left of VALUES) {
    for (const right of VALUES) {
        const a = ok(left);
        const b = err(right);
        const label = `left=${getTypeof(left)}, right=${getTypeof(right)}: `
        // TEST CODE
    }
}
```

</details>

### V8

<details>

```diff
      for (const right of VALUES) {
          const a = ok(left);
          const b = err(right);
          const label = `left=${getTypeof(left)}, right=${getTypeof(right)}: `
+         print(label +  %HaveSameMap( a, b ) );
      }
```

</details>

### JavaScriptCore

<details>

```diff
      for (const right of VALUES) {
          const a = ok(left);
          const b = err(right);
          const label = `left=${getTypeof(left)}, right=${getTypeof(right)}: `
+         print(label);
+         print(describe(a));
+         print(describe(b));
      }
```

</details>

### SpiderMonkey

<details>

```diff
      for (const right of VALUES) {
          const a = ok(left);
          const b = err(right);
          const label = `left=${getTypeof(left)}, right=${getTypeof(right)}: `
+         print(label + (shapeOf(a) === shapeOf(b)));
      }
```

</details>


## User Impact

This change these fields types to `null` or `undefined`.

- `PlainResult`
    - `Ok.err`
    - `Err.val`
- `PlainOption`
    - `None.val`

If user touch these field directly and use them, then the user code may be broken by this change.
We need to recommend to use`unwrap()` or other similar methods.

The following case is typical problem:

```ts
// This function is expected that if `result` is Ok, return number. Otherwise, return `undefined`.
function bar(result: Result<number, Error>) {
    return result.val;
}

// This `foo` was `number | undefned` previously.
// But now `foo` is `number | null | undefined`.
const foo = bar(result);

// Previously, this dumped `undefined` if result is Err.
// But now, this dump `null` or `undefined`.
console.log(foo);
```

In this case, if user specify the return type of `bar()`, then we would catch this pattern easily.
But if user does not specify types explicitly and use type inference aggressively, catching this problem would be a bit hard.