### PR TITLE
Use `released` event to invoke the workflow to publish to npm.

### DIFF
--- a/.github/workflows/publish_package_to_npm.yml
+++ b/.github/workflows/publish_package_to_npm.yml
@@ -1,7 +1,7 @@
 name: publish to npm
 on:
     release:
-        types: [created]
+        types: [released]
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
By documents, `released` event is dispatched even if we change pre-release to release.
I think this is more better for our workflow.

- https://docs.github.com/en/github-ae@latest/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release
- https://docs.github.com/en/github-ae@latest/actions/using-workflows/events-that-trigger-workflows#release