### PR TITLE
Improve the backward compatibility with v30 or former version

### DIFF
--- a/src/PlainOption/Option.ts
+++ b/src/PlainOption/Option.ts
@@ -101,7 +101,10 @@ export interface None {
     //
     // By these reasons, we should not recommend to create this object without this factory function.
     // User can create this object by hand. But it's fragile for the future change. So We should not recommend it.
-    readonly val?: null;
+    //
+    // We use `null | undefined` as more widen type rather than `null` for the backward compatibility.
+    // This definition allows to accept a value created by the old version of this library.
+    readonly val?: null | undefined;
 }
 
 export function isNone<T>(input: Option<T>): input is None {
@@ -111,6 +114,8 @@ export function isNone<T>(input: Option<T>): input is None {
 export function createNone(): None {
     const r: None = {
         ok: false,
+        // XXX: We need to fill with `null` to improve the compatibility with Next.js
+        // see https://github.com/karen-irc/option-t/pull/1256
         val: null,
     };
     return r;

--- a/src/PlainResult/Result.ts
+++ b/src/PlainResult/Result.ts
@@ -63,7 +63,10 @@ export interface Ok<T> {
     //
     // By these reasons, we should not recommend to create this object without this factory function.
     // User can create this object by hand. But it's fragile for the future change. So We should not recommend it.
-    readonly err?: null;
+    //
+    // We use `null | undefined` as more widen type rather than `null` for the backward compatibility.
+    // This definition allows to accept a value created by the old version of this library.
+    readonly err?: null | undefined;
 }
 
 export function isOk<T, E>(input: Result<T, E>): input is Ok<T> {
@@ -74,6 +77,8 @@ export function createOk<T>(val: T): Ok<T> {
     const r: Ok<T> = {
         ok: true,
         val,
+        // XXX: We need to fill with `null` to improve the compatibility with Next.js
+        // see https://github.com/karen-irc/option-t/pull/1256
         err: null,
     };
     return r;
@@ -119,7 +124,10 @@ export interface Err<E> {
     //
     // By these reasons, we should not recommend to create this object without this factory function.
     // User can create this object by hand. But it's fragile for the future change. So We should not recommend it.
-    readonly val?: null;
+    //
+    // We use `null | undefined` as more widen type rather than `null` for the backward compatibility.
+    // This definition allows to accept a value created by the old version of this library.
+    readonly val?: null | undefined;
 
     readonly err: E;
 }
@@ -131,6 +139,8 @@ export function isErr<T, E>(input: Result<T, E>): input is Err<E> {
 export function createErr<E>(err: E): Err<E> {
     const r: Err<E> = {
         ok: false,
+        // XXX: We need to fill with `null` to improve the compatibility with Next.js
+        // see https://github.com/karen-irc/option-t/pull/1256
         val: null,
         err,
     };


### PR DESCRIPTION
## Motivation

We changed the type of `PlainResult` and `PlainOption` by #1256 (this patch is included in v31). But that change disallowed to accept a value created by the v30 or prior versions  **on type level**.

This mean that the following code should work well on the running time but typescript compiler throw an type level incompatibility error if a user project enabled `--exactOptionalPropertyTypes` option.

```typescript
// This is type definition for v30 or former version.
type PaddingValueType = undefined;
type OldOk<T> = {
    ok: true;
    val: T;
    err?: PaddingValueType;
};
type OldErr<E> =  {
    ok: false;
    val?: PaddingValueType;
    err: E;
};
type OlderResult<T, E> = OldOk<T> | OldErr<E>;

declare const olderResult: OlderResult<string, Error>;

// typescript compiler will fail at here  
unwrapOkFromResult(olderResult);
```
This is a problematic in that case:

1. _application_ use v31 or later but _dependent_ library still use v30 or former and _dependant_ return a value created by v30 or former.
2. _application_ recieve a value from _dependent_ and pass the value to _application_'s other function.


## Design

To fix this, we use `null | undefined` as the padding value type.
This can accept the older type but this change does not cause a breaking change  because `bar?: null` equals to `null | undefined` when we access their property.

This change still does not allow to pass the value created by v31 or later to v30 or former.
So the following code will be type check error.

```typescript
declare const newerResult: NewResult<string, Error>;

declare function acceptOldResult(result:  OlderResult<string, Error>): void;

// this will be type check error!
acceptOldResult(newerResult);
```