### PR TITLE
Reorder the position of functions for unwrap/expect of `PlainResult`

### DIFF
--- a/src/PlainResult/expect.ts
+++ b/src/PlainResult/expect.ts
@@ -13,12 +13,6 @@ export function expectOkForResult<T, E>(input: Result<T, E>, msg: string): T | n
 }
 
 /**
- *  @deprecated
- *  Please use {@link expectOkForResult}
- */
-export const expectIsOk: typeof expectOkForResult = expectOkForResult;
-
-/**
  *  Return _input_ as `E` if the passed _input_ is `Err(E)`.
  *  Otherwise, throw `TypeError` with the passed `msg`.
  */
@@ -29,6 +23,12 @@ export function expectErrForResult<T, E>(input: Result<T, E>, msg: string): E | 
 
     return input.err;
 }
+
+/**
+ *  @deprecated
+ *  Please use {@link expectOkForResult}
+ */
+export const expectIsOk: typeof expectOkForResult = expectOkForResult;
 
 /**
  *  @deprecated

--- a/src/PlainResult/unwrap.ts
+++ b/src/PlainResult/unwrap.ts
@@ -12,12 +12,6 @@ export function unwrapOkFromResult<T>(input: Result<T, unknown>): T | never {
 }
 
 /**
- *  @deprecated
- *  Use {@link unwrapOkFromResult}
- */
-export const unwrapFromResult: typeof unwrapOkFromResult = unwrapOkFromResult;
-
-/**
  *  Return the inner `E` of a `Err(E)`.
  *
  *  @throws {TypeError}
@@ -26,3 +20,9 @@ export const unwrapFromResult: typeof unwrapOkFromResult = unwrapOkFromResult;
 export function unwrapErrFromResult<E>(input: Result<unknown, E>): E | never {
     return expectErrForResult(input, 'called with `Ok`');
 }
+
+/**
+ *  @deprecated
+ *  Use {@link unwrapOkFromResult}
+ */
+export const unwrapFromResult: typeof unwrapOkFromResult = unwrapOkFromResult;


### PR DESCRIPTION
This moves the position of deprecated functions to the bottom part of their files.