### PR TITLE
Add idiom doc about "Unwrap if _result_ is `Ok(T)`, otherwise throw an inner value of `Err(E)`"

### DIFF
--- a/docs/idiom/README.md
+++ b/docs/idiom/README.md
@@ -11,3 +11,4 @@ This document provides some idioms of this library for the interoperability to J
 
 * [Express Progressive data](./express_progress.md)
 * [Convert from PromiseSettledResult<T>) to `PlainResult`](./from_promise_settled_result.md)
+* [Unwrap if _result_ is `Ok(T)`, otherwise throw an inner value of `Err(E)`](./unwrap_ok_or_throw_err.md)

--- a/docs/idiom/unwrap_ok_or_throw_err.md
+++ b/docs/idiom/unwrap_ok_or_throw_err.md
@@ -1,0 +1,28 @@
+# Unwrap if _result_ is `Ok(T)`, otherwise throw an inner value of `Err(E)`
+
+```typescript
+import { type Result, isOk } from 'option-t/PlainResult/Result';
+import { unwrapOkFromResult, unwrapErrFromResult } from 'option-t/PlainResult/unwrap';
+
+class NotErrorInstanceError extends TypeError {
+    constructor(message?: string, options?: ErrorOptions) {
+        super(message, options);
+        this.name = this.constructor.name;
+    }
+}
+
+export function unwrapOrThrowInnerIfErr<T, E extends Error>(result: Result<T, E>): T {
+    if (isOk(result)) {
+        const val: T = unwrapOkFromResult(result);
+        return val;
+    }
+
+    const e = unwrapErrFromResult(result);
+    if (e instanceof Error) {
+        throw e;
+    }
+
+    const message = `${String(e)} is not Error instance. This function can throw Error`;
+    throw new NotErrorInstanceError(message);
+}
+```

--- a/tools/pkg_files.json
+++ b/tools/pkg_files.json
@@ -287,6 +287,7 @@
     "cjs/index.js": null,
     "docs/idiom/express_progress.md": null,
     "docs/idiom/from_promise_settled_result.md": null,
+    "docs/idiom/unwrap_ok_or_throw_err.md": null,
     "docs/idiom/README.md": null,
     "docs/operators_reverse_index.md": null,
     "docs/public_api_list.md": null,


### PR DESCRIPTION
Fix #1323