### PR TITLE
Remove the CI workflow concurrency restriction for main branch

### DIFF
--- a/.github/workflows/ci_on_main.yaml
+++ b/.github/workflows/ci_on_main.yaml
@@ -5,16 +5,6 @@ on:
         branches:
             - "main"
 
-# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
-concurrency:
-    # We would like to run this workflow for all commits in the target branch.
-    # But we need to limit the workflow concurrency to ensure a deployment order as FIFO.
-    #
-    # If we use `${{ github.workflow }}-${{ github.ref }}` and the invoked workflow for our `ci` job also has same group id,
-    # this workflow will be cancelled by the invoked workflow's `concurrency` setting.
-    # To avoid this problem, we use uuid v4 as a key to mark this workflow's uniqueness.
-    group: "789581a8-2df7-421a-afd4-02905ed031fa"
-
 jobs:
     ci:
         uses: ./.github/workflows/ci.yaml


### PR DESCRIPTION
We don't deploy in our main branch CI workflow.
So we don't have to do limit its concurrency.