### PR TITLE
Allow to run CI workflow for main branch concurrently

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -1,20 +1,10 @@
-name: CI
+name: CI workflow template
+# we need separate CI workflow template to achieve that a CI
+# for each of PRs cancellable and one for default branch should run on every commits
+# because the runner will use `concurrency.group` in the callee worfklow which is
+# configured as cancellable if we don't set `concurrency.group` to caller workflow.
 on:
-    push:
-        branches:
-            # These branches are used by bors-ng.
-            - staging
-            - trying
-        tags-ignore:
-            # Ignore for release/
-            - v*.*.*
     workflow_call:
-    pull_request:
-
-# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
-concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
 
 jobs:
     install_dependencies:

--- a/.github/workflows/ci_for_pr.yaml
+++ b/.github/workflows/ci_for_pr.yaml
@@ -1,0 +1,21 @@
+name: CI for each of Pull Requests
+
+on:
+    push:
+        branches:
+            # These branches are used by bors-ng.
+            - staging
+            - trying
+        tags-ignore:
+            # Ignore for release/
+            - v*.*.*
+    pull_request:
+
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    ci:
+        uses: ./.github/workflows/_ci.yaml

--- a/.github/workflows/ci_on_main.yaml
+++ b/.github/workflows/ci_on_main.yaml
@@ -5,16 +5,6 @@ on:
         branches:
             - "main"
 
-# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
-concurrency:
-    # We would like to run this workflow for all commits in the target branch.
-    # But we need to limit the workflow concurrency to ensure a deployment order as FIFO.
-    #
-    # If we use `${{ github.workflow }}-${{ github.ref }}` and the invoked workflow for our `ci` job also has same group id,
-    # this workflow will be cancelled by the invoked workflow's `concurrency` setting.
-    # To avoid this problem, we use uuid v4 as a key to mark this workflow's uniqueness.
-    group: "789581a8-2df7-421a-afd4-02905ed031fa"
-
 jobs:
     ci:
-        uses: ./.github/workflows/ci.yaml
+        uses: ./.github/workflows/_ci.yaml


### PR DESCRIPTION
We don't deploy in our main branch CI workflow. We don't have to do limit its concurrency.

This tris #1388 again.