### PR TITLE
Revert d78460a

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -63,7 +63,7 @@ module.exports = {
             },
         },
         {
-            'files': ['*.js', '*.mjs'],
+            'files': ['*.mjs'],
             'parserOptions': {
                 'sourceType': 'module',
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "option-t",
   "version": "32.6.1",
   "description": "Types and implementations whose APIs are inspired by Rust's `Option<T>` and `Result<T, E>`.",
-  "type": "module",
+  "type": "commonjs",
   "files": [
     "CHANGELOG.md",
     "CHANGELOG_OLD.md",


### PR DESCRIPTION
This reverts commit d78460aa907f4c1ea19622b9ae5c94a6b4d976d0. #1409

If we set `type` in package.json to `module`, an user project which uses typescript with `moduleResolution=node16` will cause an type resolution error.

I guess tsc has some bugs. So we need to workaround.

Reopen https://github.com/karen-irc/option-t/issues/816