### PR TITLE
Remove `typings` field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,5 @@
     "prettier": "^2.7.1",
     "typescript": "^4.5.5"
   },
-  "sideEffects": false,
-  "typings": "./cjs/index.d.ts"
+  "sideEffects": false
 }


### PR DESCRIPTION
We don't provide to allow to import `option-t` for a long time. So we should remove it.