### PR TITLE
Fix the regression: import some types from ClassicOption.d.ts corrrectly

### DIFF
--- a/src/ClassOption/ClassicOption.d.ts
+++ b/src/ClassOption/ClassicOption.d.ts
@@ -203,7 +203,7 @@ export abstract class ClassicOptionBase<T> implements ClassicOptionable<T> {
  *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
-interface ClassicSome<T> extends ClassicOptionable<T> {
+export interface ClassicSome<T> extends ClassicOptionable<T> {
     readonly isSome: true;
     readonly isNone: false;
     unwrap(): T;
@@ -215,7 +215,7 @@ interface ClassicSome<T> extends ClassicOptionable<T> {
  *      We keep this only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */
-interface ClassicNone<T> extends ClassicOptionable<T> {
+export interface ClassicNone<T> extends ClassicOptionable<T> {
     readonly isSome: false;
     readonly isNone: true;
     unwrap(): never;

--- a/src/ClassResult/ClassicResult.d.ts
+++ b/src/ClassResult/ClassicResult.d.ts
@@ -1,4 +1,8 @@
-import type { ClassicOption, Some, None } from '../ClassOption/ClassicOption.js';
+import type {
+    ClassicOption,
+    ClassicSome as Some,
+    ClassicNone as None,
+} from '../ClassOption/ClassicOption.js';
 import type { TransformFn, RecoveryFromErrorFn, EffectFn } from '../internal/Function.js';
 
 /**


### PR DESCRIPTION
This bug was introduced in 4c31b67e68d4a6e1adde989fbd23fee810bdcfa6 (#905)