### PR TITLE
Update TypeScript compiler to 4.9 (RC)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-config-prettier": "^8.5.0",
     "picomatch": "^2.3.1",
     "prettier": "^2.7.1",
-    "typescript": "^4.9.1-beta"
+    "typescript": "^4.9.2-rc"
   },
   "sideEffects": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,10 +3109,10 @@ type-fest@^1.0.1, type-fest@^1.2.1, type-fest@^1.2.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-typescript@^4.9.1-beta:
-  version "4.9.1-beta"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.1-beta.tgz#b5fe1b26f2fe3aeb14790927b25372bebf351c67"
-  integrity sha512-D4c0t1+sMOS5Hy8DQsGFfEYUuKzolXhf+7e/N0Td5etBPflEYzVwWLBrbVgHpLpLC53OJQCtxk31+NWO2SBPaA==
+typescript@^4.9.2-rc:
+  version "4.9.2-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.2-rc.tgz#3525dbeb8458a8c98ce7d60724e4a9380d7b46e7"
+  integrity sha512-Ly9UUxJBfiiFjfegI1gsW9FI8Xhw1cuwRMBJ4wdYg+UXZR4VnZvD1OnBDj/iQ2U+tWbWEjYqJ5xx1Cwr4Vsa4w==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-4-9-rc/

This tsc introduces [Decorators proposal's `accessor` syntax](https://github.com/tc39/proposal-decorators) and it will be emit to d.ts.

However, I don't think it (this commit) causes breaking change directly. Followings are reasons:

1. `accessor` is not allowed with target=ES5. We need to mark it as a breaking change if we bump up it.
2. Accepting `accessor` syntax will change type's shape. It also would be a breaking change individually.