### PR TITLE
Implement `tryCatchIntoResult()` + ensure thrown value is `Error` instance

### DIFF
--- a/__tests__/PlainResult/try_catch/try_catch.test.mjs
+++ b/__tests__/PlainResult/try_catch/try_catch.test.mjs
@@ -1,8 +1,11 @@
 import test from 'ava';
 
-import { isOk, isErr } from '../../__dist/esm/PlainResult/Result.mjs';
-import { tryCatchIntoResult } from '../../__dist/esm/PlainResult/tryCatch.mjs';
-import { unwrapErrFromResult, unwrapOkFromResult } from '../../__dist/esm/PlainResult/unwrap.mjs';
+import { isOk, isErr } from '../../../__dist/esm/PlainResult/Result.mjs';
+import { tryCatchIntoResult } from '../../../__dist/esm/PlainResult/tryCatch.mjs';
+import {
+    unwrapErrFromResult,
+    unwrapOkFromResult,
+} from '../../../__dist/esm/PlainResult/unwrap.mjs';
 
 test('output=Ok(T)', (t) => {
     t.plan(3);

--- a/__tests__/PlainResult/try_catch/try_catch_with_ensure_error.test.mjs
+++ b/__tests__/PlainResult/try_catch/try_catch_with_ensure_error.test.mjs
@@ -1,0 +1,57 @@
+import test from 'ava';
+import { webcrypto } from 'node:crypto';
+
+import { isOk, isErr } from '../../../__dist/esm/PlainResult/Result.mjs';
+import { tryCatchIntoResultWithEnsureError } from '../../../__dist/esm/PlainResult/tryCatch.mjs';
+import {
+    unwrapErrFromResult,
+    unwrapOkFromResult,
+} from '../../../__dist/esm/PlainResult/unwrap.mjs';
+
+test('output=Ok(T)', (t) => {
+    t.plan(3);
+
+    const EXPECTED = Math.random();
+    const actual = tryCatchIntoResultWithEnsureError(() => {
+        t.pass();
+        return EXPECTED;
+    });
+
+    t.true(isOk(actual), 'should be Ok(T)');
+    t.is(unwrapOkFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test('output=Err(Error)', (t) => {
+    t.plan(3);
+
+    const EXPECTED = new Error(Math.random());
+    const actual = tryCatchIntoResultWithEnsureError(() => {
+        t.pass();
+        throw EXPECTED;
+    });
+
+    t.true(isErr(actual), 'should be Err(E)');
+    t.is(unwrapErrFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test('If producer throw non-Error-instance value', (t) => {
+    t.plan(3);
+
+    const EXPECT_THROWN = webcrypto.randomUUID();
+    const actual = t.throws(
+        () => {
+            tryCatchIntoResultWithEnsureError(() => {
+                t.pass();
+                throw EXPECT_THROWN;
+            });
+        },
+        {
+            instanceOf: TypeError,
+            message: `The input is not an \`Error\` instance. The actual is \`${String(
+                EXPECT_THROWN
+            )}\``,
+        }
+    );
+
+    t.is(actual.cause, EXPECT_THROWN, `should set Error.cause`);
+});

--- a/__tests__/PlainResult/try_catch_async/try_catch_async.test.mjs
+++ b/__tests__/PlainResult/try_catch_async/try_catch_async.test.mjs
@@ -1,8 +1,11 @@
 import test from 'ava';
 
-import { isOk, isErr } from '../../__dist/esm/PlainResult/Result.mjs';
-import { tryCatchIntoResultAsync } from '../../__dist/esm/PlainResult/tryCatchAsync.mjs';
-import { unwrapErrFromResult, unwrapOkFromResult } from '../../__dist/esm/PlainResult/unwrap.mjs';
+import { isOk, isErr } from '../../../__dist/esm/PlainResult/Result.mjs';
+import { tryCatchIntoResultAsync } from '../../../__dist/esm/PlainResult/tryCatchAsync.mjs';
+import {
+    unwrapErrFromResult,
+    unwrapOkFromResult,
+} from '../../../__dist/esm/PlainResult/unwrap.mjs';
 
 test('output=Ok(T): producer is async fn', async (t) => {
     t.plan(4);

--- a/__tests__/PlainResult/try_catch_async/try_catch_with_ensure_error_async.test.mjs
+++ b/__tests__/PlainResult/try_catch_async/try_catch_with_ensure_error_async.test.mjs
@@ -1,0 +1,178 @@
+import test from 'ava';
+
+import { isOk, isErr } from '../../../__dist/esm/PlainResult/Result.mjs';
+import { tryCatchIntoResultWithEnsureErrorAsync } from '../../../__dist/esm/PlainResult/tryCatchAsync.mjs';
+import {
+    unwrapErrFromResult,
+    unwrapOkFromResult,
+} from '../../../__dist/esm/PlainResult/unwrap.mjs';
+
+test('output=Ok(T): producer is async fn', async (t) => {
+    t.plan(4);
+
+    const EXPECTED = Math.random();
+    const result = tryCatchIntoResultWithEnsureErrorAsync(async () => {
+        t.pass();
+        return EXPECTED;
+    });
+
+    t.true(result instanceof Promise, 'result should be Promise');
+
+    const actual = await result;
+    t.true(isOk(actual), 'should be Ok(T)');
+    t.is(unwrapOkFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test('output=Ok(T): producer is normal fn', async (t) => {
+    t.plan(4);
+
+    const EXPECTED = Math.random();
+    const result = tryCatchIntoResultWithEnsureErrorAsync(() => {
+        t.pass();
+        return Promise.resolve(EXPECTED);
+    });
+
+    t.true(result instanceof Promise, 'result should be Promise');
+
+    const actual = await result;
+    t.true(isOk(actual), 'should be Ok(T)');
+    t.is(unwrapOkFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test('output=Err(Error): producer is async fn', async (t) => {
+    t.plan(4);
+
+    const EXPECTED = new Error(Math.random());
+    const result = tryCatchIntoResultWithEnsureErrorAsync(async () => {
+        t.pass();
+        throw EXPECTED;
+    });
+
+    t.true(result instanceof Promise, 'result should be Promise');
+
+    const actual = await result;
+    t.true(isErr(actual), 'should be Err(E)');
+    t.is(unwrapErrFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test('output=Err(Error): producer is normal fn', async (t) => {
+    t.plan(4);
+
+    const EXPECTED = new Error(Math.random());
+    const result = tryCatchIntoResultWithEnsureErrorAsync(() => {
+        t.pass();
+        return Promise.reject(EXPECTED);
+    });
+
+    t.true(result instanceof Promise, 'result should be Promise');
+
+    const actual = await result;
+    t.true(isErr(actual), 'should be Err(E)');
+    t.is(unwrapErrFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test('output=Err(Error): producer is normal fn but throw an error before return any Promise', async (t) => {
+    t.plan(4);
+
+    const EXPECTED = new Error(Math.random());
+
+    const result = tryCatchIntoResultWithEnsureErrorAsync(() => {
+        t.pass();
+        throw EXPECTED;
+    });
+
+    t.true(result instanceof Promise, 'result should be Promise');
+
+    const actual = await result;
+    t.true(isErr(actual), 'should be Err(E)');
+    t.is(unwrapErrFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test('if producer does not return Promise, case = return', async (t) => {
+    t.plan(2);
+
+    await t.throwsAsync(
+        async () => {
+            await tryCatchIntoResultWithEnsureErrorAsync(() => {
+                t.pass('producer is called');
+                return Math.random();
+            });
+        },
+        {
+            instanceOf: TypeError,
+            message: '`producer` must return Promise',
+        }
+    );
+});
+
+test('if producer is normal function and reject a Promise with not-Error-instance value', async (t) => {
+    t.plan(3);
+
+    const THROWN_EXPECTED = Math.random();
+
+    const actual = await t.throwsAsync(
+        async () => {
+            await tryCatchIntoResultWithEnsureErrorAsync(() => {
+                t.pass('producer is called');
+                return Promise.reject(THROWN_EXPECTED);
+            });
+            t.fail('unreachable here');
+        },
+        {
+            instanceOf: TypeError,
+            message: `The input is not an \`Error\` instance. The actual is \`${String(
+                THROWN_EXPECTED
+            )}\``,
+        }
+    );
+
+    t.is(actual.cause, THROWN_EXPECTED, 'should set Error.cause');
+});
+
+test('if producer is normal function and throw a not-Error-instance value before return any `Promise`', async (t) => {
+    t.plan(3);
+
+    const THROWN_EXPECTED = Math.random();
+
+    const actual = await t.throwsAsync(
+        async () => {
+            await tryCatchIntoResultWithEnsureErrorAsync(() => {
+                t.pass('producer is called');
+                throw THROWN_EXPECTED;
+            });
+            t.fail('unreachable here');
+        },
+        {
+            instanceOf: TypeError,
+            message: `The input is not an \`Error\` instance. The actual is \`${String(
+                THROWN_EXPECTED
+            )}\``,
+        }
+    );
+
+    t.is(actual.cause, THROWN_EXPECTED, 'should set Error.cause');
+});
+
+test('if producer is async function and throw a not-Error-instance value', async (t) => {
+    t.plan(3);
+
+    const THROWN_EXPECTED = Math.random();
+
+    const actual = await t.throwsAsync(
+        async () => {
+            await tryCatchIntoResultWithEnsureErrorAsync(async () => {
+                t.pass('producer is called');
+                throw THROWN_EXPECTED;
+            });
+            t.fail('unreachable here');
+        },
+        {
+            instanceOf: TypeError,
+            message: `The input is not an \`Error\` instance. The actual is \`${String(
+                THROWN_EXPECTED
+            )}\``,
+        }
+    );
+
+    t.is(actual.cause, THROWN_EXPECTED, 'should set Error.cause');
+});

--- a/src/PlainResult/tryCatch.ts
+++ b/src/PlainResult/tryCatch.ts
@@ -1,3 +1,4 @@
+import { assertIsError } from '../internal/assert.js';
 import type { ProducerFn } from '../internal/Function.js';
 import { type Result, createOk, createErr } from './Result.js';
 
@@ -15,6 +16,27 @@ export function tryCatchIntoResult<T>(producer: ProducerFn<T>): Result<T, unknow
         return ok;
     } catch (e: unknown) {
         const err = createErr<unknown>(e);
+        return err;
+    }
+}
+
+/**
+ *  - This function converts the returend value from _producer_ into `Ok(TValue)`.
+ *  - If _producer_ throw an `Error` instance, this returns it with wrapping `Err(Error)`.
+ *  - Otherwise, If _producer_ throw a not `Error` instance, then this throw `TypeError`.
+ *
+ *  NOTE:
+ *  1. An user should narrow the scope of _producer_ to make it predictable that is in `Err(E)`.
+ *  2. This function requires ES2022's `Error.cause` to get an actual thrown object.
+ */
+export function tryCatchIntoResultWithEnsureError<T>(producer: ProducerFn<T>): Result<T, Error> {
+    try {
+        const value: T = producer();
+        const ok = createOk<T>(value);
+        return ok;
+    } catch (e: unknown) {
+        assertIsError(e);
+        const err = createErr<Error>(e);
         return err;
     }
 }

--- a/src/PlainResult/tryCatchAsync.ts
+++ b/src/PlainResult/tryCatchAsync.ts
@@ -1,6 +1,7 @@
-import { assertIsPromise } from '../internal/assert.js';
+import { assertIsError, assertIsPromise } from '../internal/assert.js';
 import { ERR_MSG_PRODUCER_MUST_RETURN_PROMISE } from '../internal/ErrorMessage.js';
 import type { AsyncProducerFn } from '../internal/Function.js';
+import { mapErrForResult } from './mapErr.js';
 import { type Result, createOk, createErr } from './Result.js';
 
 /**
@@ -25,4 +26,31 @@ export function tryCatchIntoResultAsync<T>(
 
     const wrapped: Promise<Result<T, unknown>> = value.then(createOk, createErr);
     return wrapped;
+}
+
+/**
+ *  - This function converts the returend value from _producer_ into `Ok(TValue)`.
+ *  - If _producer_ throw an `Error` instance, this returns it with wrapping `Err(Error)`.
+ *  - Otherwise, If _producer_ throw a not `Error` instance, then this throw `TypeError`.
+ *
+ *  NOTE:
+ *  1. An user should narrow the scope of _producer_ to make it predictable that is in `Err(E)`.
+ *  2. This function requires ES2022's `Error.cause` to get an actual thrown object.
+ */
+export function tryCatchIntoResultWithEnsureErrorAsync<T>(
+    producer: AsyncProducerFn<T>
+): Promise<Result<T, Error>> {
+    const result = tryCatchIntoResultAsync(producer);
+    const ensured: Promise<Result<T, Error>> = result.then(ensureErrorInResultErr);
+    return ensured;
+}
+
+function ensureErrorInResultErr<T>(input: Result<T, unknown>): Result<T, Error> {
+    const ensured = mapErrForResult(input, checkThrownIsError);
+    return ensured;
+}
+
+function checkThrownIsError(thrown: unknown): Error {
+    assertIsError(thrown);
+    return thrown;
 }

--- a/src/internal/assert.ts
+++ b/src/internal/assert.ts
@@ -7,3 +7,14 @@ export function assertIsPromise(
         throw new TypeError(message);
     }
 }
+
+export function assertIsError(input: unknown): asserts input is Error {
+    if (!(input instanceof Error)) {
+        const stringified = String(input);
+        const message = `The input is not an \`Error\` instance. The actual is \`${stringified}\``;
+        // We don't throw Node's AssertionError because the code size will be larger.
+        throw new TypeError(message, {
+            cause: input,
+        });
+    }
+}

--- a/tools/public_api/table.mjs
+++ b/tools/public_api/table.mjs
@@ -629,6 +629,7 @@ export const apiTable = Object.freeze({
     'PlainResult/tryCatch': {
         'exports': [
             'tryCatchIntoResult',
+            'tryCatchIntoResultWithEnsureError',
         ]
     },
     'PlainResult/tryCatchAsync': {

--- a/tools/public_api/table.mjs
+++ b/tools/public_api/table.mjs
@@ -635,6 +635,7 @@ export const apiTable = Object.freeze({
     'PlainResult/tryCatchAsync': {
         'exports': [
             'tryCatchIntoResultAsync',
+            'tryCatchIntoResultWithEnsureErrorAsync',
         ]
     },
     'PlainResult/transpose': {


### PR DESCRIPTION
This attempt to fix #1357.

Originally, I had planed to introduce an operator that returning `Result<T, Error>` from try-catch statement without checking a thrown value in #1357. But it's pattern is not a type safe.

I think this package should provide a type safe API first (and it's most common use case).

For the future, we may introduce `unsafeTryCatchIntoResult()` without checking to ensure `Error`.