### PR TITLE
Remove `::set-output` usage in GH Action

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -7,7 +7,7 @@ runs:
         - name: Get yarn cache directory path
           shell: bash
           id: yarn-cache-dir-path
-          run: echo "::set-output name=dir::$(yarn cache dir)"
+          run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         - name: Restore dependencies from cache
           id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
           uses: actions/cache@v3


### PR DESCRIPTION
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/