### PR TITLE
Fix the order of conditions in `exports` field in package.json

### DIFF
--- a/tools/package_json_rewriter/transformer/add_exports_field/ExportEntry.mjs
+++ b/tools/package_json_rewriter/transformer/add_exports_field/ExportEntry.mjs
@@ -284,15 +284,16 @@ function constructDualPackagePathValue({ cjs, esm, dts }) {
     //  * `["node", "import"]` is used as _defaultEnv_ for its ES Module resolver.
     //
     // see also https://nodejs.org/api/esm.html#esm_conditional_exports
-    return {
+    return Object.freeze({
+        // > Note that the "types" condition should always come first in "exports".
+        // https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing
+        'types': dts,
         'import': esm,
         'require': cjs,
-        // https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#packagejson-exports-imports-and-self-referencing
-        'types': dts,
         // _default_ should be placed to the last.
         // https://nodejs.org/api/esm.html#esm_conditional_exports
         'default': esm,
-    };
+    });
 }
 
 function constructPathValue({ filepath, dts }) {
@@ -304,11 +305,11 @@ function constructPathValue({ filepath, dts }) {
     //  * `["node", "import"]` is used as _defaultEnv_ for its ES Module resolver.
     //
     // see also https://nodejs.org/api/esm.html#esm_conditional_exports
-    return {
+    return Object.freeze({
         // https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#packagejson-exports-imports-and-self-referencing
         'types': dts,
         // _default_ should be placed to the last.
         // https://nodejs.org/api/esm.html#esm_conditional_exports
         'default': filepath,
-    };
+    });
 }


### PR DESCRIPTION
> Note that the "types" condition should always come first in "exports".
> https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing