### PR TITLE
Fix a regression: Fail to import `.d.cts` from other `.d.cts`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ __build_cjs__cp_cjs_to_cjsdir: __build_cjs__rename_js_to_cjs clean_dist
 
 .PHONY: __build_cjs__cp_dcts_to_cjsdir
 __build_cjs__cp_dcts_to_cjsdir: __build_cjs_rename_dts_to_dcts clean_dist
-	$(NODE_BIN) $(CURDIR)/tools/cp_files.mjs --basedir $(TMP_CJS_DIR) --source '$(TMP_CJS_DIR)/**/*.$(DTS_EXTENSION_GLOB)' --destination $(DIST_COMMONJS_DIR)
+	$(NPM_BIN)/babel $(TMP_CJS_DIR) --out-dir $(DIST_COMMONJS_DIR) --extensions=.cts --no-babelrc --config-file $(CURDIR)/tools/babel/babelrc.d.cts.mjs --keep-file-extension
 
 .PHONY: __build_cjs_rename_dts_to_dcts
 __build_cjs_rename_dts_to_dcts: __build_cjs__create_tmp_cjs

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@babel/cli": "^7.20.7",
     "@babel/core": "^7.20.12",
+    "@babel/plugin-syntax-typescript": "^7.20.0",
     "@babel/preset-env": "^7.20.2",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",

--- a/tools/babel/babelrc.d.cts.mjs
+++ b/tools/babel/babelrc.d.cts.mjs
@@ -1,0 +1,10 @@
+export default {
+    'plugins': [
+        ['@babel/plugin-syntax-typescript', {
+            dts: true,
+        }],
+        ['./babel-plugin-modify-ext.mjs', {
+            extension: '.cjs',
+        }],
+    ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,6 +536,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-syntax-typescript@^7.20.0":
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz#4e9a0cfc769c85689b77a2e642d24e9f697fc8c7"
+  integrity sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.19.0"
+
 "@babel/plugin-transform-arrow-functions@^7.18.6":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz#bea332b0e8b2dab3dafe55a163d8227531ab0551"


### PR DESCRIPTION
This fix a regression since e3601aa4ffa3b6468eccbff497c31d20539ad94a.
The regression causes some not intuitive type resolution error.