### PR TITLE
Preserve `import type {} from ...` syntax for d.cts

### DIFF
--- a/tools/babel/babel-plugin-modify-ext.mjs
+++ b/tools/babel/babel-plugin-modify-ext.mjs
@@ -14,7 +14,15 @@ function replaceLastExtensionWith(oldExtension, newExtension, name) {
     return replaced;
 }
 
-function rewriter(t, path, state, declarationFactory) {
+/**
+ * @param {import('@babel/core').types} t
+ * @param {import('@babel/core').NodePath<ImportDeclaration|ExportNamedDeclaration>} path
+ * @param {import('@babel/core').PluginPass} state
+ * @param {*} declarationFactory
+ * @param {*} kindGetter
+ * @returns {void}
+ */
+function rewriter(t, path, state, declarationFactory, kindGetter) {
     const option = state.opts;
     const extension = option.extension;
     assert.ok(typeof extension === 'string', 'opts.extension must be set');
@@ -33,6 +41,7 @@ function rewriter(t, path, state, declarationFactory) {
     const specifiers = node.specifiers;
     const filepathValue = source.value;
     const currentExt = nodePath.extname(filepathValue);
+    const kind = kindGetter(node);
 
     let newLiteral;
     if (currentExt === '') {
@@ -43,24 +52,66 @@ function rewriter(t, path, state, declarationFactory) {
     }
 
     const newSource = t.stringLiteral(newLiteral);
-    const declaration = declarationFactory(specifiers, newSource);
+    const declaration = declarationFactory(specifiers, newSource, kind);
     path.replaceWith(declaration);
 }
 
+/**
+ * @typedef {import('@babel/core').types.ImportDeclaration} ImportDeclaration
+ */
+
+/**
+ * @param {import('@babel/core').types} t
+ * @param {import('@babel/core').NodePath<ImportDeclaration>} path
+ * @param {import('@babel/core').PluginPass} state
+ * @param {*} declarationFactory
+ * @returns {void}
+ */
+function rewriterForImportDeclaration(t, path, state, declarationFactory) {
+    rewriter(t, path, state, declarationFactory, (node) => {
+        const importKind = node.importKind;
+        return importKind;
+    });
+}
+
+/**
+ * @typedef {import('@babel/core').types.ExportNamedDeclaration} ExportNamedDeclaration
+ */
+
+/**
+ * @param {import('@babel/core').types} t
+ * @param {import('@babel/core').NodePath<ExportNamedDeclaration>} path
+ * @param {import('@babel/core').PluginPass} state
+ * @param {*} declarationFactory
+ * @returns {void}
+ */
+function rewriterForExportNamedDeclaration(t, path, state, declarationFactory) {
+    rewriter(t, path, state, declarationFactory, (node) => {
+        const exportKind = node.exportKind;
+        return exportKind;
+    });
+}
+
+/**
+ * @param {import('@babel/core')} param0
+ * @returns {import('@babel/core').PluginObj}
+ */
 export default function babelAddMjsSuffixPlugin({ types: t }) {
     return {
         visitor: {
             ImportDeclaration(path, state) {
-                rewriter(t, path, state, (specifiers, source) => {
+                rewriterForImportDeclaration(t, path, state, (specifiers, source, kind) => {
                     const d = t.importDeclaration(specifiers, source);
+                    d.importKind = kind;
                     t.assertImportDeclaration(d);
                     return d;
                 });
             },
 
             ExportNamedDeclaration(path, state) {
-                rewriter(t, path, state, (specifiers, source) => {
+                rewriterForExportNamedDeclaration(t, path, state, (specifiers, source, kind) => {
                     const d = t.exportNamedDeclaration(null, specifiers, source);
+                    d.exportKind = kind;
                     t.assertExportNamedDeclaration(d);
                     return d;
                 });


### PR DESCRIPTION
Since 9ae75978b7e666b7a87f4400dafe94b08e0ff7ba,
`import type {} from '...';` statement in d.cts will be transformed to `import {} from '...';` statement.

This is not a regression but it causes a bit difference between d.cts and d.ts. So this patch fix it.