### PR TITLE
Mark PlainOption as "weak" deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,6 @@ This can express that there is some values or some error information _as a plain
 This does not have any property method on its prototype. But this allows no including unused methods of them.
 
 
-#### Wrapper objects (deprecated)
-
-[See this guide](./docs/wrapper_objects.md).
-
-
 ### How to import
 
 **You can use [these paths](./docs/public_api_list.md) in both of CommonJS style and ES Module style.**
@@ -204,6 +199,17 @@ you can use these paths:
 ### Idioms
 
 - You can see [some idioms](./docs/idiom/) of this library for the interoperability to JavaScript world.
+
+
+### Deprecated APIs
+
+We don't have any concrete plan to remove followings but do not recommend to use them in almost cases.
+
+
+#### Wrapper objects (deprecated)
+
+[See this guide](./docs/wrapper_objects.md).
+
 
 
 ### See also

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ All APIs are TypeScript ready.
     * [`Undefinable<T>` (`T | undefined`)](./src/Undefinable/)
     * [`Maybe<T>` (`T | null | undefined`)](./src/Maybe/)
     * plain objects
-        * [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./src/PlainOption/)
         * [`Result<T, E>` (`{ ok: true; val: T } | { ok: false; err: E; }`)](./src/PlainResult/)
+        * [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./src/PlainOption/) (_weak deprecated_)
 * [Wrapper objects](./docs/wrapper_objects.md) ([__*deprecated*__](https://github.com/karen-irc/option-t/issues/459)).
 
 
@@ -150,11 +150,6 @@ This can express a value of `T` type or `undefined`.
 #### [`Maybe<T>` (`T | null | undefined`)](./src/Maybe/)
 
 This can express a value of `T` type, `null`, or `undefined`.
-
-####  [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./src/PlainOption/)
-
-This can express that there is some values or none _as a plain object_.
-This does not have any property method on its prototype. But this allows no including unused methods of them.
 
 #### [`Result<T, E>` (`{ ok: true; val: T } | { ok: false; err: E; }`)](./src/PlainResult/)
 
@@ -204,6 +199,13 @@ you can use these paths:
 ### Deprecated APIs
 
 We don't have any concrete plan to remove followings but do not recommend to use them in almost cases.
+
+####  [`Option<T>` (`{ ok: true; val: T } | { ok: false; }`)](./src/PlainOption/) (weak deprecated)
+
+**Basically, we don't recommend to use this type. Use `Nullable`, `Undefinable<T>`, or `Maybe<T>` to express an absence of a value instead. In JavaScript, they would cover almost usecases. Probably, you might not have to use this type.**
+
+This can express that there is some values or none _as a plain object_.
+This does not have any property method on its prototype. But this allows no including unused methods of them.
 
 
 #### Wrapper objects (deprecated)

--- a/src/PlainOption/Option.ts
+++ b/src/PlainOption/Option.ts
@@ -1,5 +1,9 @@
 /**
+ *  @deprecated
+ *  Consider to use `Nullable<T>`, `Undefinable<T>`, or `Maybe<T>` to express an absence of a value.
+ *  In JavaScript, they satisfy almost use cases. Probably, you might not have to use this type.
  *
+ *  --------
  *  This is [_option type_](https://en.wikipedia.org/wiki/Option_type).
  *
  *  ## CAUTION:


### PR DESCRIPTION
In JavaScript world, simple nullable type is better to express an absence of a value than this kind of tagged union type. 

`T | null` or `T | undefined` are common idiom for almost use-cases, are interoperable, and make a thing simple. Furthermore we provide a utility toolkit for their types.

This kind of type is still useful to contains null or undefined as not an absence value. But it’s a rare case. There is no reason to recommend to use it in general use cases.

Thus, now, we stop to recommend to use this and mark it as deprecated.

This does not mean that we remove this type in near future. It’s just to draw down from a recommended types.

Probably we will not be able to remove this for backward compatibility. Furthermore, it would not be costly to keep this type because:

1. This type does not affect a bundle size by tree shaking support.
2. The implementation does not make our build pipeline complex.
