### PR TITLE
Expose `lib/ClassicOption` and `lib/ClassicResult`

### DIFF
--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1,5 +1,7 @@
 /**
  *  @deprecated
+ *      Use `option-t/lib/ClassicOption` instead.
+ *
  *      We keep this file only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -1,5 +1,7 @@
 /**
  *  @deprecated
+ *      Use `option-t/lib/ClassicResult` instead.
+ *
  *      We keep this file only for backward compatibility.
  *      See https://github.com/karen-irc/option-t/issues/459
  */

--- a/tools/package_json_rewriter/transformer/add_exports_field/compatibility.mjs
+++ b/tools/package_json_rewriter/transformer/add_exports_field/compatibility.mjs
@@ -19,6 +19,8 @@ export function addHistoricalPathToExportsFields(o, histricalJSPathSeq) {
     }
 
     const DIR_SUBPATH = [
+        'ClassicOption',
+        'ClassicResult',
         'Maybe',
         'Nullable',
         'PlainOption',

--- a/tools/public_api/table.mjs
+++ b/tools/public_api/table.mjs
@@ -827,6 +827,8 @@ const COMPAT_DESCRIPTOR = Object.freeze({
 });
 
 export const legacyApiTable = Object.freeze({
+    'cjs/ClassicOption': COMPAT_DESCRIPTOR,
+    'cjs/ClassicResult': COMPAT_DESCRIPTOR,
     'cjs/Maybe/ErrorMessage': COMPAT_DESCRIPTOR,
     'cjs/Maybe/Maybe': COMPAT_DESCRIPTOR,
     'cjs/Maybe/and': COMPAT_DESCRIPTOR,
@@ -967,6 +969,8 @@ export const legacyApiTable = Object.freeze({
     'cjs/Undefinable/unwrapOrElseAsync': COMPAT_DESCRIPTOR,
     'cjs/Undefinable/xor': COMPAT_DESCRIPTOR,
     'cjs/index': COMPAT_DESCRIPTOR,
+    'esm/ClassicOption': COMPAT_DESCRIPTOR,
+    'esm/ClassicResult': COMPAT_DESCRIPTOR,
     'esm/Maybe/ErrorMessage': COMPAT_DESCRIPTOR,
     'esm/Maybe/Maybe': COMPAT_DESCRIPTOR,
     'esm/Maybe/and': COMPAT_DESCRIPTOR,
@@ -1107,6 +1111,8 @@ export const legacyApiTable = Object.freeze({
     'esm/Undefinable/unwrapOrElseAsync': COMPAT_DESCRIPTOR,
     'esm/Undefinable/xor': COMPAT_DESCRIPTOR,
     'esm/index': COMPAT_DESCRIPTOR,
+    'lib/ClassicOption': COMPAT_DESCRIPTOR,
+    'lib/ClassicResult': COMPAT_DESCRIPTOR,
     'lib/Maybe/ErrorMessage': COMPAT_DESCRIPTOR,
     'lib/Maybe/Maybe': COMPAT_DESCRIPTOR,
     'lib/Maybe/and': COMPAT_DESCRIPTOR,


### PR DESCRIPTION
By this change, we make these path deprecated to import a legacy wrapper object

- `lib/Option`
- `lib/Result`.