### PR TITLE
Remove some deprecations

### DIFF
--- a/src/PlainOption/Option.ts
+++ b/src/PlainOption/Option.ts
@@ -51,7 +51,6 @@ export type Option<T> = Some<T> | None;
  */
 export interface Some<T> {
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use {@link isSome()} or {@link isNone()} operator to get an inner value.
      *
@@ -61,7 +60,6 @@ export interface Some<T> {
      */
     readonly ok: true;
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use `unwrap()` operator to get an inner value.
      *
@@ -97,7 +95,6 @@ export function createSome<T>(val: T): Some<T> {
  */
 export interface None {
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use {@link isSome()} or {@link isNone()} operator to get an inner value.
      *
@@ -136,7 +133,6 @@ export interface None {
     // We use `null | undefined` as more widen type rather than `null` for the backward compatibility.
     // This definition allows to accept a value created by the old version of this library.
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use `unwrap()` operator to get an inner value.
      *

--- a/src/PlainResult/Result.ts
+++ b/src/PlainResult/Result.ts
@@ -25,7 +25,7 @@ export type Result<T, E> = Ok<T> | Err<E>;
  *  This type contain a success value _T_.
  *
  *  You can create this type value and get an inner value in this type by hand.
- *  But we recommend to use factory and utility functions for forward compatibility.
+ *  But we recommend to use the factory {@link createOk()} and utility functions for forward compatibility.
  *
  *      - `createOk()` to create a value of `Ok(T)`.
  *      - `isOk()` to check whether the value is `Ok(T)`.
@@ -112,7 +112,7 @@ export function createOk<T>(val: T): Ok<T> {
  *  This type contain a failure information _E_.
  *
  *  You can create this type value and get an inner value in this type by hand.
- *  But we recommend to use factory and utility functions for forward compatibility.
+ *  But we recommend to use the factory {@link createErr()} and utility functions for forward compatibility.
  *
  *      - `createErr()` to create a value of `Err(E)`.
  *      - `isErr()` to check whether the value is `Err(E)`.

--- a/src/PlainResult/Result.ts
+++ b/src/PlainResult/Result.ts
@@ -35,7 +35,6 @@ export type Result<T, E> = Ok<T> | Err<E>;
  */
 export interface Ok<T> {
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use {@link isOk()} or {@link isErr()} operator to get an inner value.
      *
@@ -45,7 +44,6 @@ export interface Ok<T> {
      */
     readonly ok: true;
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use `unwrapOk()` operator to get an inner value.
      *
@@ -85,7 +83,6 @@ export interface Ok<T> {
     // We use `null | undefined` as more widen type rather than `null` for the backward compatibility.
     // This definition allows to accept a value created by the old version of this library.
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use `unwrapErr()` operator to get an inner value.
      *
@@ -124,7 +121,6 @@ export function createOk<T>(val: T): Ok<T> {
  */
 export interface Err<E> {
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use {@link isOk()} or {@link isErr()} operator to get an inner value.
      *
@@ -164,7 +160,6 @@ export interface Err<E> {
     // We use `null | undefined` as more widen type rather than `null` for the backward compatibility.
     // This definition allows to accept a value created by the old version of this library.
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use `unwrapOk()` operator to get an inner value.
      *
@@ -175,7 +170,6 @@ export interface Err<E> {
     readonly val?: null | undefined;
 
     /**
-     *  @deprecated
      *  Don't touch this property directly from an user project.
      *  Instead, use `unwrapErr()` operator to get an inner value.
      *

--- a/src/PlainResult/unwrapOrThrowError.ts
+++ b/src/PlainResult/unwrapOrThrowError.ts
@@ -7,10 +7,7 @@ import { unwrapErrFromResult, unwrapOkFromResult } from './unwrap.js';
  *  Unwraps _input_, returns the content of an `Ok(T)`.
  *  Otherwise, this function throw the contained `Error` in `Err(Error)`.
  *
- *  @deprecated
- *  This function is marked as _deprecated_ as meaning of __not recommend to use__.
- *
- *  This marking displays this function usages with strikethrough line decolation on an editor.
+ *  __We DO NOT RECCOMEND TO USE THIS function generally__.
  *
  *  This function is provided only to improve an interoperability with the world using "throw error" convention.
  *  __We do not recommend to use this function__.


### PR DESCRIPTION
## Remove `@deprecated` from `PlainOption` & `PlainResult` members

They were introduced since fc6d10a05fe67ec8ed486c617e945bbb806b6c94.
I thought we should recommend to use operator functions,
but their deprecation marking is confusing
for a 3rd party user that uses a value returned from our user project.

Such 3rd party user would not install this package,
but then they need to handle their members with deprecation warnings.

It's not friendly behavior.

## Remove `@deprecated` tag from `unwrapOrThrowErrorFromResult()`

It's marked as `@deprecated` since 2067d466d6097f4bc0bfc9cfa11ec8f9dbc55e88.
After some considerations, we conclude that we don't recommend to use it, but we do not have to mark this as deprecated too.