### PR TITLE
Fix CI fatal error for `make test_package_install` job

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -162,6 +162,9 @@ jobs:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare_ci
 
+            # This line is required to avoid fatal: detected dubious ownership in repository at ~.
+            # I think we can remove this line after we move to some monorepo.
+            - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
             - run: make test_package_install -j
               env:
                   CI: true


### PR DESCRIPTION
the error is:

```
git checkout HEAD -- /__w/option-t/option-t/package.json /__w/option-t/option-t/yarn.lock
fatal: detected dubious ownership in repository at '/__w/option-t/option-t'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/option-t/option-t
```

I try to fix this by changing the command to simple `git reset --hard`.