### PR TITLE
Back `Classic*` to to ES5 class idiom to avoid test errors

### DIFF
--- a/packages/option-t/src/ClassicOption/ClassicOption.js
+++ b/packages/option-t/src/ClassicOption/ClassicOption.js
@@ -15,22 +15,20 @@
  *
  *  The usecase example is a `React.PropTypes.
  */
-export class ClassicOptionBase {
-    constructor(ok, val) {
-        /**
-         *  @private
-         *  @type   {boolean}
-         */
-        this.ok = ok;
+export function ClassicOptionBase(ok, val) {
+    /**
+     *  @private
+     *  @type   {boolean}
+     */
+    this.ok = ok;
 
-        /**
-         *  @private
-         *  @type   {T|undefined}
-         */
-        this.val = val;
+    /**
+     *  @private
+     *  @type   {T|undefined}
+     */
+    this.val = val;
 
-        Object.seal(this);
-    }
+    Object.seal(this);
 }
 ClassicOptionBase.prototype = Object.freeze({
     /**

--- a/packages/option-t/src/ClassicResult/ClassicResult.js
+++ b/packages/option-t/src/ClassicResult/ClassicResult.js
@@ -18,25 +18,23 @@ import { createClassicSome, createClassicNone } from '../ClassicOption/ClassicOp
  *
  *  The usecase example is a `React.PropTypes`.
  */
-export class ClassicResultBase {
-    constructor(ok, val, err) {
-        /**
-         *  @private
-         *  @type   {boolean}
-         */
-        this._isOk = ok;
-        /**
-         *  @private
-         *  @type   {T}
-         */
-        this._v = val;
-        /**
-         *  @private
-         *  @type   {E}
-         */
-        this._e = err;
-        Object.seal(this);
-    }
+export function ClassicResultBase(ok, val, err) {
+    /**
+     *  @private
+     *  @type   {boolean}
+     */
+    this._isOk = ok;
+    /**
+     *  @private
+     *  @type   {T}
+     */
+    this._v = val;
+    /**
+     *  @private
+     *  @type   {E}
+     */
+    this._e = err;
+    Object.seal(this);
 }
 ClassicResultBase.prototype = Object.freeze({
     /**


### PR DESCRIPTION
This is required for https://github.com/karen-irc/option-t/issues/1236

We shifted to ES6 class constructor since c8752a4493b081bc24d07e00fd1569ed91f4b19a.

However, in ES6 class, the following pattern is an error. We should back to ES5.

```js
class A {}
A.prototype = {};
```