### PR TITLE
Fix the regression: the published package does not contain any docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@ INNER_PACKAGES_DIR := $(CURDIR)/packages
 MAIN_PKG := $(INNER_PACKAGES_DIR)/option-t
 API_TEST_PKG := $(INNER_PACKAGES_DIR)/api_tests
 
+DIST_DIR := $(MAIN_PKG)/__dist
+
 NODE_BIN := node
 NPM_MOD_DIR := $(CURDIR)/node_modules
 NPM_BIN := $(NPM_MOD_DIR)/.bin
 NPM_CMD := npm
 
-PROJECT_NPMRC := $(CURDIR)/.npmrc
+PROJECT_NPMRC := $(DIST_DIR)/.npmrc
 
 ESLINT_APPLIED_EXTENSIONS := .js,.jsx,cjs,.mjs,.ts,.tsx,.cts,.mts
 

--- a/packages/option-t/Makefile
+++ b/packages/option-t/Makefile
@@ -256,4 +256,4 @@ prepublish: ## Run some commands for 'npm run prepublish'
 
 .PHONY: publish
 publish: ## Run some commands for 'npm publish'
-	npm publish $(DIST_DIR)/
+	cd $(DIST_DIR) && npm publish


### PR DESCRIPTION
This regression happens since  v33.5.3 b47c5b21752b61285e07327b59e076de2863e60e