### PR TITLE
Remove bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,0 @@
-# This should be sorted with a status label,
-status = ["build_and_test"]


### PR DESCRIPTION
We have stopped to use https://bors.tech/ for a long time ago. And we can switch to use GitHub's merge queue now. https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue