### PR TITLE
Mark `and`/`equal`/`or` that are exported by `Plain{Option,Result}/index` deprecated

### DIFF
--- a/packages/option-t/src/PlainOption/compat/v33.ts
+++ b/packages/option-t/src/PlainOption/compat/v33.ts
@@ -15,10 +15,8 @@ export {
     expectSome,
 } from '../Option.js';
 
-export { andForOption } from '../and.js';
 export { andThenForOption } from '../andThen.js';
 export { andThenAsyncForOption } from '../andThenAsync.js';
-export { equalForOption } from '../equal.js';
 export { filterForOption } from '../filter.js';
 export { flattenForOption } from '../flatten.js';
 export { inspectOption } from '../inspect.js';
@@ -28,7 +26,6 @@ export { mapOrForOption } from '../mapOr.js';
 export { mapOrAsyncForOption } from '../mapOrAsync.js';
 export { mapOrElseForOption } from '../mapOrElse.js';
 export { mapOrElseAsyncForOption } from '../mapOrElseAsync.js';
-export { orForOption } from '../or.js';
 export { orElseForOption } from '../orElse.js';
 export { orElseAsyncForOption } from '../orElseAsync.js';
 export { transposeForOption } from '../transpose.js';
@@ -37,10 +34,10 @@ export { unwrapOrElseFromOption } from '../unwrapOrElse.js';
 export { unwrapOrElseAsyncFromOption } from '../unwrapOrElseAsync.js';
 
 import { expectSome, unwrapSome } from '../Option.js';
-import { andForOption } from '../and.js';
+import { andForOption as andForOptionOriginal } from '../and.js';
 import { andThenForOption } from '../andThen.js';
 import { andThenAsyncForOption } from '../andThenAsync.js';
-import { equalForOption } from '../equal.js';
+import { equalForOption as equalForOptionOriginal } from '../equal.js';
 import { filterForOption } from '../filter.js';
 import { flattenForOption } from '../flatten.js';
 import { inspectOption } from '../inspect.js';
@@ -50,7 +47,7 @@ import { mapOrForOption } from '../mapOr.js';
 import { mapOrAsyncForOption } from '../mapOrAsync.js';
 import { mapOrElseForOption } from '../mapOrElse.js';
 import { mapOrElseAsyncForOption } from '../mapOrElseAsync.js';
-import { orForOption } from '../or.js';
+import { orForOption as orForOptionOriginal } from '../or.js';
 import { orElseForOption } from '../orElse.js';
 import { orElseAsyncForOption } from '../orElseAsync.js';
 import { transposeForOption } from '../transpose.js';
@@ -72,9 +69,15 @@ export const unwrap: typeof unwrapSome = unwrapSome;
 
 /**
  *  @deprecated
- *  Please use {@link andForOption} in `option-t/PlainOption/and`.
+ *  Please use `andForOption` in `option-t/PlainOption/and`.
  */
-export const and: typeof andForOption = andForOption;
+export const and: typeof andForOptionOriginal = andForOptionOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `andForOption` in `option-t/PlainOption/and`.
+ */
+export const andForOption: typeof andForOptionOriginal = andForOptionOriginal;
 
 /**
  *  @deprecated
@@ -90,9 +93,15 @@ export const andThenAsync: typeof andThenAsyncForOption = andThenAsyncForOption;
 
 /**
  *  @deprecated
- *  Please use {@link equalForOption} in `option-t/PlainOption/equal`.
+ *  Please use `equalForOption` in `option-t/PlainOption/equal`.
  */
-export const equal: typeof equalForOption = equalForOption;
+export const equal: typeof equalForOptionOriginal = equalForOptionOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `equalForOption` in `option-t/PlainOption/equal`.
+ */
+export const equalForOption: typeof equalForOptionOriginal = equalForOptionOriginal;
 
 /**
  *  @deprecated
@@ -150,9 +159,15 @@ export const mapOrElseAsync: typeof mapOrElseAsyncForOption = mapOrElseAsyncForO
 
 /**
  *  @deprecated
- *  Please use {@link orForOption} in `option-t/PlainOption/or`.
+ *  Please use `orForOption` in `option-t/PlainOption/or`.
  */
-export const or: typeof orForOption = orForOption;
+export const or: typeof orForOptionOriginal = orForOptionOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `orForOption` in `option-t/PlainOption/or`.
+ */
+export const orForOption: typeof orForOptionOriginal = orForOptionOriginal;
 
 /**
  *  @deprecated

--- a/packages/option-t/src/PlainOption/index.ts
+++ b/packages/option-t/src/PlainOption/index.ts
@@ -36,10 +36,8 @@ export {
     expectSome,
 } from './Option.js';
 
-export { andForOption } from './and.js';
 export { andThenForOption } from './andThen.js';
 export { andThenAsyncForOption } from './andThenAsync.js';
-export { equalForOption } from './equal.js';
 export { filterForOption } from './filter.js';
 export { flattenForOption } from './flatten.js';
 export { inspectOption } from './inspect.js';
@@ -49,7 +47,6 @@ export { mapOrForOption } from './mapOr.js';
 export { mapOrAsyncForOption } from './mapOrAsync.js';
 export { mapOrElseForOption } from './mapOrElse.js';
 export { mapOrElseAsyncForOption } from './mapOrElseAsync.js';
-export { orForOption } from './or.js';
 export { orElseForOption } from './orElse.js';
 export { orElseAsyncForOption } from './orElseAsync.js';
 export { transposeForOption } from './transpose.js';
@@ -75,10 +72,10 @@ export const expect: typeof expectSome = expectSome;
  */
 export const unwrap: typeof unwrapSome = unwrapSome;
 
-import { andForOption } from './and.js';
+import { andForOption as andForOptionOriginal } from './and.js';
 import { andThenForOption } from './andThen.js';
 import { andThenAsyncForOption } from './andThenAsync.js';
-import { equalForOption } from './equal.js';
+import { equalForOption as equalForOptionOriginal } from './equal.js';
 import { filterForOption } from './filter.js';
 import { flattenForOption } from './flatten.js';
 import { inspectOption } from './inspect.js';
@@ -88,7 +85,7 @@ import { mapOrForOption } from './mapOr.js';
 import { mapOrAsyncForOption } from './mapOrAsync.js';
 import { mapOrElseForOption } from './mapOrElse.js';
 import { mapOrElseAsyncForOption } from './mapOrElseAsync.js';
-import { orForOption } from './or.js';
+import { orForOption as orForOptionOriginal } from './or.js';
 import { orElseForOption } from './orElse.js';
 import { orElseAsyncForOption } from './orElseAsync.js';
 import { transposeForOption } from './transpose.js';
@@ -98,10 +95,17 @@ import { unwrapOrElseAsyncFromOption } from './unwrapOrElseAsync.js';
 
 /**
  *  @deprecated
- *  Please use {@link andForOption}
+ *  Please use `andForOption` in `option-t/PlainOption/and`.
  *  This might be removed in v34 or later.
  */
-export const and: typeof andForOption = andForOption;
+export const and: typeof andForOptionOriginal = andForOptionOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `andForOption` in `option-t/PlainOption/and`.
+ *  This might be removed in v34 or later.
+ */
+export const andForOption: typeof andForOptionOriginal = andForOptionOriginal;
 
 /**
  *  @deprecated
@@ -119,10 +123,17 @@ export const andThenAsync: typeof andThenAsyncForOption = andThenAsyncForOption;
 
 /**
  *  @deprecated
- *  Please use {@link equalForOption}
+ *  Please use `equalForOption` in `option-t/PlainOption/equal`
  *  This might be removed in v34 or later.
  */
-export const equal: typeof equalForOption = equalForOption;
+export const equal: typeof equalForOptionOriginal = equalForOptionOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `equalForOption` in `option-t/PlainOption/equal`
+ *  This might be removed in v34 or later.
+ */
+export const equalForOption: typeof equalForOptionOriginal = equalForOptionOriginal;
 
 /**
  *  @deprecated
@@ -189,10 +200,17 @@ export const mapOrElseAsync: typeof mapOrElseAsyncForOption = mapOrElseAsyncForO
 
 /**
  *  @deprecated
- *  Please use {@link orForOption}
+ *  Please use `orForOption` in `option-t/PlainOption/or`
  *  This might be removed in v34 or later.
  */
-export const or: typeof orForOption = orForOption;
+export const orForOption: typeof orForOptionOriginal = orForOptionOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `orForOption` in `option-t/PlainOption/or`
+ *  This might be removed in v34 or later.
+ */
+export const or: typeof orForOptionOriginal = orForOptionOriginal;
 
 /**
  *  @deprecated

--- a/packages/option-t/src/PlainResult/compat/v33.ts
+++ b/packages/option-t/src/PlainResult/compat/v33.ts
@@ -17,10 +17,8 @@ export {
     expectErr,
 } from '../Result.js';
 
-export { andForResult } from '../and.js';
 export { andThenForResult } from '../andThen.js';
 export { andThenAsyncForResult } from '../andThenAsync.js';
-export { equalForResult } from '../equal.js';
 export { flattenForResult } from '../flatten.js';
 export { inspectOkOfResult, inspectErrOfResult, inspectBothOfResult } from '../inspect.js';
 export { mapForResult } from '../map.js';
@@ -31,7 +29,6 @@ export { mapOrElseForResult } from '../mapOrElse.js';
 export { mapOrElseAsyncForResult } from '../mapOrElseAsync.js';
 export { mapErrForResult } from '../mapErr.js';
 export { mapErrAsyncForResult } from '../mapErrAsync.js';
-export { orForResult } from '../or.js';
 export { orElseForResult } from '../orElse.js';
 export { orElseAsyncForResult } from '../orElseAsync.js';
 export { transposeNullableForResult, transposeUndefinableForResult } from '../transpose.js';
@@ -44,10 +41,10 @@ import {
     toOptionFromOk as toOptionFromOkFn,
     toOptionFromErr as toOptionFromErrFn,
 } from '../toOption.js';
-import { andForResult } from '../and.js';
+import { andForResult as andForResultOriginal } from '../and.js';
 import { andThenForResult } from '../andThen.js';
 import { andThenAsyncForResult } from '../andThenAsync.js';
-import { equalForResult } from '../equal.js';
+import { equalForResult as equalForResultOriginal } from '../equal.js';
 import { flattenForResult } from '../flatten.js';
 import { inspectOkOfResult, inspectErrOfResult, inspectBothOfResult } from '../inspect.js';
 import { mapForResult } from '../map.js';
@@ -58,7 +55,7 @@ import { mapOrElseForResult } from '../mapOrElse.js';
 import { mapOrElseAsyncForResult } from '../mapOrElseAsync.js';
 import { mapErrForResult } from '../mapErr.js';
 import { mapErrAsyncForResult } from '../mapErrAsync.js';
-import { orForResult } from '../or.js';
+import { orForResult as orForResultOriginal } from '../or.js';
 import { orElseForResult } from '../orElse.js';
 import { orElseAsyncForResult } from '../orElseAsync.js';
 import {
@@ -108,9 +105,15 @@ export const toOptionFromErr: typeof toOptionFromErrFn = toOptionFromErrFn;
 
 /**
  *  @deprecated
- *  Please use {@link andForResult} in `option-t/PlainResult/and`.
+ *  Please use `andForResult` in `option-t/PlainResult/and`.
  */
-export const and: typeof andForResult = andForResult;
+export const and: typeof andForResultOriginal = andForResultOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `andForResult` in `option-t/PlainResult/and`.
+ */
+export const andForResult: typeof andForResultOriginal = andForResultOriginal;
 
 /**
  *  @deprecated
@@ -126,9 +129,15 @@ export const andThenAsync: typeof andThenAsyncForResult = andThenAsyncForResult;
 
 /**
  *  @deprecated
- *  Please use {@link equalForResult} in `option-t/PlainResult/equal`.
+ *  Please use `equalForResult` in `option-t/PlainResult/equal`.
  */
-export const equal: typeof equalForResult = equalForResult;
+export const equal: typeof equalForResultOriginal = equalForResultOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `equalForResult` in `option-t/PlainResult/equal`.
+ */
+export const equalForResult: typeof equalForResultOriginal = equalForResultOriginal;
 
 /**
  *  @deprecated
@@ -204,9 +213,15 @@ export const mapErrAsync: typeof mapErrAsyncForResult = mapErrAsyncForResult;
 
 /**
  *  @deprecated
- *  Please use {@link orForResult} in `option-t/PlainResult/or`.
+ *  Please use `orForResult` in `option-t/PlainResult/or`.
  */
-export const or: typeof orForResult = orForResult;
+export const or: typeof orForResultOriginal = orForResultOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `orForResult` in `option-t/PlainResult/or`.
+ */
+export const orForResult: typeof orForResultOriginal = orForResultOriginal;
 
 /**
  *  @deprecated

--- a/packages/option-t/src/PlainResult/index.ts
+++ b/packages/option-t/src/PlainResult/index.ts
@@ -37,10 +37,8 @@ export {
     expectErr,
 } from './Result.js';
 
-export { andForResult } from './and.js';
 export { andThenForResult } from './andThen.js';
 export { andThenAsyncForResult } from './andThenAsync.js';
-export { equalForResult } from './equal.js';
 export { flattenForResult } from './flatten.js';
 export { inspectOkOfResult, inspectErrOfResult, inspectBothOfResult } from './inspect.js';
 export { mapForResult } from './map.js';
@@ -51,7 +49,6 @@ export { mapOrElseForResult } from './mapOrElse.js';
 export { mapOrElseAsyncForResult } from './mapOrElseAsync.js';
 export { mapErrForResult } from './mapErr.js';
 export { mapErrAsyncForResult } from './mapErrAsync.js';
-export { orForResult } from './or.js';
 export { orElseForResult } from './orElse.js';
 export { orElseAsyncForResult } from './orElseAsync.js';
 export { transposeNullableForResult, transposeUndefinableForResult } from './transpose.js';
@@ -64,10 +61,10 @@ import {
     toOptionFromOk as toOptionFromOkFn,
     toOptionFromErr as toOptionFromErrFn,
 } from './toOption.js';
-import { andForResult } from './and.js';
+import { andForResult as andForResultOriginal } from './and.js';
 import { andThenForResult } from './andThen.js';
 import { andThenAsyncForResult } from './andThenAsync.js';
-import { equalForResult } from './equal.js';
+import { equalForResult as equalForResultOriginal } from './equal.js';
 import { flattenForResult } from './flatten.js';
 import { inspectOkOfResult, inspectErrOfResult, inspectBothOfResult } from './inspect.js';
 import { mapForResult } from './map.js';
@@ -78,7 +75,7 @@ import { mapOrElseForResult } from './mapOrElse.js';
 import { mapOrElseAsyncForResult } from './mapOrElseAsync.js';
 import { mapErrForResult } from './mapErr.js';
 import { mapErrAsyncForResult } from './mapErrAsync.js';
-import { orForResult } from './or.js';
+import { orForResult as orForResultOriginal } from './or.js';
 import { orElseForResult } from './orElse.js';
 import { orElseAsyncForResult } from './orElseAsync.js';
 import {
@@ -142,10 +139,17 @@ export const toOptionFromErr: typeof toOptionFromErrFn = toOptionFromErrFn;
 
 /**
  *  @deprecated
- *  Please use {@link andForResult}
+ *  Please use `andForResult` in `option-t/PlainResult/and`.
  *  This might be removed in v34 or later.
  */
-export const and: typeof andForResult = andForResult;
+export const and: typeof andForResultOriginal = andForResultOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `andForResult` in `option-t/PlainResult/and`.
+ *  This might be removed in v34 or later.
+ */
+export const andForResult: typeof andForResultOriginal = andForResultOriginal;
 
 /**
  *  @deprecated
@@ -163,10 +167,17 @@ export const andThenAsync: typeof andThenAsyncForResult = andThenAsyncForResult;
 
 /**
  *  @deprecated
- *  Please use {@link equalForResult}
+ *  Please use `equalForResult` in `option-t/PlainResult/equal`
  *  This might be removed in v34 or later.
  */
-export const equal: typeof equalForResult = equalForResult;
+export const equal: typeof equalForResultOriginal = equalForResultOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `equalForResult` in `option-t/PlainResult/equal`
+ *  This might be removed in v34 or later.
+ */
+export const equalForResult: typeof equalForResultOriginal = equalForResultOriginal;
 
 /**
  *  @deprecated
@@ -254,10 +265,17 @@ export const mapErrAsync: typeof mapErrAsyncForResult = mapErrAsyncForResult;
 
 /**
  *  @deprecated
- *  Please use {@link orForResult}
+ *  Please use `orForResult` in `option-t/PlainResult/or`.
  *  This might be removed in v34 or later.
  */
-export const or: typeof orForResult = orForResult;
+export const or: typeof orForResultOriginal = orForResultOriginal;
+
+/**
+ *  @deprecated
+ *  Please use `orForResult` in `option-t/PlainResult/or`.
+ *  This might be removed in v34 or later.
+ */
+export const orForResult: typeof orForResultOriginal = orForResultOriginal;
 
 /**
  *  @deprecated


### PR DESCRIPTION
see #1624