### PR TITLE
Update `engines` field to `>=24.5.0`

### DIFF
--- a/packages/option-t/package.json
+++ b/packages/option-t/package.json
@@ -4,7 +4,7 @@
     "description": "A toolkit of Nullable/Option/Result type implementation in ECMAScript. Their APIs are inspired by Rust's `Option<T>` and `Result<T, E>`.",
     "type": "module",
     "engines": {
-        "node": ">=16.20.0"
+        "node": ">=24.5.0"
     },
     "files": [
         "esm/",


### PR DESCRIPTION
Fix https://github.com/option-t/option-t/issues/2490

To simplify our supported environments, we bump the minimum version which specified in `engines`.