### PR TITLE
export `experimental_<TypeName>Operators` directly to allow tree-shaking with rollup 4.46.2

### DIFF
--- a/packages/option-t/src/maybe/index.ts
+++ b/packages/option-t/src/maybe/index.ts
@@ -28,15 +28,12 @@ export { unwrapOrForMaybe } from './operators/unwrap_or.js';
 export { unwrapOrElseForMaybe } from './operators/unwrap_or_else.js';
 export { unwrapOrElseAsyncForMaybe } from './operators/unwrap_or_else_async.js';
 
-import * as maybeOperators from './internal/intermediate_operators.js';
-
 /**
  *  @experimental
  *      This API is still experimental. We might change this without any breaking changes.
  */
 // FIXME: https://github.com/option-t/option-t/issues/2535
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const experimental_MaybeOperators: typeof maybeOperators = maybeOperators;
+export * as experimental_MaybeOperators from './internal/intermediate_operators.js';
 
 // XXX:
 //  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.

--- a/packages/option-t/src/nullable/index.ts
+++ b/packages/option-t/src/nullable/index.ts
@@ -27,15 +27,12 @@ export { unwrapOrForNullable } from './operators/unwrap_or.js';
 export { unwrapOrElseForNullable } from './operators/unwrap_or_else.js';
 export { unwrapOrElseAsyncForNullable } from './operators/unwrap_or_else_async.js';
 
-import * as nullableOperators from './internal/intermediate_operators.js';
-
 /**
  *  @experimental
  *      This API is still experimental. We might change this without any breaking changes.
  */
 // FIXME: https://github.com/option-t/option-t/issues/2536
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const experimental_NullableOperators: typeof nullableOperators = nullableOperators;
+export * as experimental_NullableOperators from './internal/intermediate_operators.js';
 
 // XXX:
 //  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.

--- a/packages/option-t/src/plain_result/index.ts
+++ b/packages/option-t/src/plain_result/index.ts
@@ -71,15 +71,11 @@ export { unwrapOrElseForResult } from './operators/unwrap_or_else.js';
 export { unwrapOrElseAsyncForResult } from './operators/unwrap_or_else_async.js';
 export { unwrapOrThrowForResult } from './operators/unwrap_or_throw.js';
 
-import * as resultOperators from './internal/intermediate_operators.js';
-
 /**
  *  @experimental
  *      This API is still experimental. We might change this without any breaking changes.
  */
-// FIXME: https://github.com/option-t/option-t/issues/2547
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const experimental_ResultOperators: typeof resultOperators = resultOperators;
+export * as experimental_ResultOperators from './internal/intermediate_operators.js';
 
 // XXX:
 //  We don't expose these itens that is unsafe operation.

--- a/packages/option-t/src/undefinable/index.ts
+++ b/packages/option-t/src/undefinable/index.ts
@@ -30,15 +30,12 @@ export { unwrapOrForUndefinable } from './operators/unwrap_or.js';
 export { unwrapOrElseForUndefinable } from './operators/unwrap_or_else.js';
 export { unwrapOrElseAsyncForUndefinable } from './operators/unwrap_or_else_async.js';
 
-import * as undefinableOperators from './internal/intermediate_operators.js';
-
 /**
  *  @experimental
  *      This API is still experimental. We might change this without any breaking changes.
  */
 // FIXME: https://github.com/option-t/option-t/issues/2549
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const experimental_UndefinableOperators: typeof undefinableOperators = undefinableOperators;
+export * as experimental_UndefinableOperators from './internal/intermediate_operators.js';
 
 // XXX:
 //  _and_ operator is equivalent of `a && b` so we don't ship it by this default set.


### PR DESCRIPTION
Fix https://github.com/option-t/option-t/issues/2560