### PR TITLE
nullable: Add tests to check exported aliases are the expected identity

### DIFF
--- a/packages/api_tests/__tests__/nullable/core/expect.test.mjs
+++ b/packages/api_tests/__tests__/nullable/core/expect.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { expectNotNull } from 'option-t/nullable/nullable';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -40,4 +43,10 @@ test('pass undefined', (t) => {
         result = expectNotNull(NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE, EXPECTED_MSG);
     });
     t.is(result, NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.expectNotNull, expectNotNull);
+    t.is(NullableNamespace.expectNotNull, expectNotNull);
+    t.is(NullableRootCompatV54.expectNotNull, expectNotNull);
 });

--- a/packages/api_tests/__tests__/nullable/core/is_not_null.test.mjs
+++ b/packages/api_tests/__tests__/nullable/core/is_not_null.test.mjs
@@ -1,0 +1,12 @@
+import test from 'ava';
+
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
+import { isNotNull } from 'option-t/nullable/nullable';
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.isNotNull, isNotNull);
+    t.is(NullableNamespace.isNotNull, isNotNull);
+    t.is(NullableRootCompatV54.isNotNull, isNotNull);
+});

--- a/packages/api_tests/__tests__/nullable/core/is_null.test.mjs
+++ b/packages/api_tests/__tests__/nullable/core/is_null.test.mjs
@@ -1,0 +1,12 @@
+import test from 'ava';
+
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
+import { isNull } from 'option-t/nullable/nullable';
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.isNull, isNull);
+    t.is(NullableNamespace.isNull, isNull);
+    t.is(NullableRootCompatV54.isNull, isNull);
+});

--- a/packages/api_tests/__tests__/nullable/core/unwrap.test.mjs
+++ b/packages/api_tests/__tests__/nullable/core/unwrap.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { unwrapNullable } from 'option-t/nullable/nullable';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -31,4 +34,10 @@ test(`pass ${NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
         result = unwrapNullable(NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE);
     });
     t.is(result, NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.unwrapNullable, unwrapNullable);
+    t.is(NullableNamespace.unwrapNullable, unwrapNullable);
+    t.is(NullableRootCompatV54.unwrapNullable, unwrapNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/and.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/and.test.mjs
@@ -37,3 +37,7 @@ for (const [a, b, expected] of list) {
         t.is(andForNullable(a, b), expected);
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/nullable/operators/and_then.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/and_then.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
 import { andThenForNullable } from 'option-t/nullable/and_then';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -41,4 +44,11 @@ test(`pass ${NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
     });
 
     t.is(result, NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.andThenForNullable, andThenForNullable);
+    t.is(NullableRoot.NullableOperator.andThen, andThenForNullable);
+    t.is(NullableNamespace.andThen, andThenForNullable);
+    t.is(NullableRootCompatV54.andThenForNullable, andThenForNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/and_then_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/and_then_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
 import { andThenAsyncForNullable } from 'option-t/nullable/and_then_async';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -52,4 +55,11 @@ test(`pass ${NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE}`, async (t) => {
     t.true(result instanceof Promise, 'result should be Promise');
     const actual = await result;
     t.is(actual, NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.andThenAsyncForNullable, andThenAsyncForNullable);
+    t.is(NullableRoot.NullableOperator.andThenAsync, andThenAsyncForNullable);
+    t.is(NullableNamespace.andThenAsync, andThenAsyncForNullable);
+    t.is(NullableRootCompatV54.andThenAsyncForNullable, andThenAsyncForNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/filter/filter.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/filter/filter.test.mjs
@@ -33,3 +33,7 @@ test('input is null', (t) => {
     });
     t.is(actual, null);
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/nullable/operators/filter/filter_with_ensure_type.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/filter/filter_with_ensure_type.test.mjs
@@ -33,3 +33,7 @@ test('input is null', (t) => {
     });
     t.is(actual, null);
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/nullable/operators/filter_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/filter_async.test.mjs
@@ -31,3 +31,7 @@ test('input is null', async (t) => {
     });
     t.is(actual, null);
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/nullable/operators/inspect.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/inspect.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
 import { inspectNullable } from 'option-t/nullable/inspect';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -38,4 +41,11 @@ test(`pass ${NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
     });
 
     t.is(result, INPUT);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.inspectNullable, inspectNullable);
+    t.is(NullableRoot.NullableOperator.inspect, inspectNullable);
+    t.is(NullableNamespace.inspect, inspectNullable);
+    t.is(NullableRootCompatV54.inspectNullable, inspectNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/map.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/map.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
 import { mapForNullable } from 'option-t/nullable/map';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -52,3 +55,10 @@ for (const [src, def] of testcases) {
         );
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.mapForNullable, mapForNullable);
+    t.is(NullableRoot.NullableOperator.map, mapForNullable);
+    t.is(NullableNamespace.map, mapForNullable);
+    t.is(NullableRootCompatV54.mapForNullable, mapForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/map_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/map_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
 import { mapAsyncForNullable } from 'option-t/nullable/map_async';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -67,3 +70,10 @@ for (const [src, def] of testcases) {
         );
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.mapAsyncForNullable, mapAsyncForNullable);
+    t.is(NullableRoot.NullableOperator.mapAsync, mapAsyncForNullable);
+    t.is(NullableNamespace.mapAsync, mapAsyncForNullable);
+    t.is(NullableRootCompatV54.mapAsyncForNullable, mapAsyncForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/map_or.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/map_or.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
 import { mapOrForNullable } from 'option-t/nullable/map_or';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -82,3 +85,10 @@ test(`pass ${NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.mapOrForNullable, mapOrForNullable);
+    t.is(NullableRoot.NullableOperator.mapOr, mapOrForNullable);
+    t.is(NullableNamespace.mapOr, mapOrForNullable);
+    t.is(NullableRootCompatV54.mapOrForNullable, mapOrForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/map_or_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/map_or_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
 import { mapOrAsyncForNullable } from 'option-t/nullable/map_or_async';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -106,3 +109,10 @@ test('pass undefined', async (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.mapOrAsyncForNullable, mapOrAsyncForNullable);
+    t.is(NullableRoot.NullableOperator.mapOrAsync, mapOrAsyncForNullable);
+    t.is(NullableNamespace.mapOrAsync, mapOrAsyncForNullable);
+    t.is(NullableRootCompatV54.mapOrAsyncForNullable, mapOrAsyncForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/map_or_else.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/map_or_else.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
 import { mapOrElseForNullable } from 'option-t/nullable/map_or_else';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -102,3 +105,10 @@ test('pass undefined', (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.mapOrElseForNullable, mapOrElseForNullable);
+    t.is(NullableRoot.NullableOperator.mapOrElse, mapOrElseForNullable);
+    t.is(NullableNamespace.mapOrElse, mapOrElseForNullable);
+    t.is(NullableRootCompatV54.mapOrElseForNullable, mapOrElseForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/map_or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/map_or_else_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
 import { mapOrElseAsyncForNullable } from 'option-t/nullable/map_or_else_async';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = null;
@@ -138,3 +141,10 @@ test('pass undefined', async (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.mapOrElseAsyncForNullable, mapOrElseAsyncForNullable);
+    t.is(NullableRoot.NullableOperator.mapOrElseAsync, mapOrElseAsyncForNullable);
+    t.is(NullableNamespace.mapOrElseAsync, mapOrElseAsyncForNullable);
+    t.is(NullableRootCompatV54.mapOrElseAsyncForNullable, mapOrElseAsyncForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/ok_or.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/ok_or.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
 import { okOrForNullable } from 'option-t/nullable/ok_or';
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -38,4 +41,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
 
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErr(actual), DEFAULT_ERR, 'should contain the expected');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.okOrForNullable, okOrForNullable);
+    t.is(NullableRoot.NullableOperator.okOr, okOrForNullable);
+    t.is(NullableNamespace.okOr, okOrForNullable);
+    t.is(NullableRootCompatV54.okOrForNullable, okOrForNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/ok_or_else.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/ok_or_else.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { okOrElseForNullable } from 'option-t/nullable/ok_or_else';
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
@@ -48,4 +51,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
 
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErr(actual), DEFAULT_ERR, 'should contain the expected');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.okOrElseForNullable, okOrElseForNullable);
+    t.is(NullableRoot.NullableOperator.okOrElse, okOrElseForNullable);
+    t.is(NullableNamespace.okOrElse, okOrElseForNullable);
+    t.is(NullableRootCompatV54.okOrElseForNullable, okOrElseForNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/ok_or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/ok_or_else_async.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { okOrElseAsyncForNullable } from 'option-t/nullable/ok_or_else_async';
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
@@ -57,4 +60,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, async (t) => {
     const actual = await result;
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErr(actual), DEFAULT_ERR, 'should contain the expected');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.okOrElseAsyncForNullable, okOrElseAsyncForNullable);
+    t.is(NullableRoot.NullableOperator.okOrElseAsync, okOrElseAsyncForNullable);
+    t.is(NullableNamespace.okOrElseAsync, okOrElseAsyncForNullable);
+    t.is(NullableRootCompatV54.okOrElseAsyncForNullable, okOrElseAsyncForNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/or.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/or.test.mjs
@@ -37,3 +37,7 @@ for (const [a, b, expected] of list) {
         t.is(orForNullable(a, b), expected);
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/nullable/operators/or_else.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/or_else.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { orElseForNullable } from 'option-t/nullable/or_else';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -44,4 +47,11 @@ test(`pass ${NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
     });
 
     t.is(result, NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.orElseForNullable, orElseForNullable);
+    t.is(NullableRoot.NullableOperator.orElse, orElseForNullable);
+    t.is(NullableNamespace.orElse, orElseForNullable);
+    t.is(NullableRootCompatV54.orElseForNullable, orElseForNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/or_else_async.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { orElseAsyncForNullable } from 'option-t/nullable/or_else_async';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
@@ -53,4 +56,11 @@ test(`pass ${NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE}`, async (t) => {
     t.true(result instanceof Promise, 'result should be Promise');
     const actual = await result;
     t.is(actual, NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.orElseAsyncForNullable, orElseAsyncForNullable);
+    t.is(NullableRoot.NullableOperator.orElseAsync, orElseAsyncForNullable);
+    t.is(NullableNamespace.orElseAsync, orElseAsyncForNullable);
+    t.is(NullableRootCompatV54.orElseAsyncForNullable, orElseAsyncForNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/to_plain_result/to_err.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/to_plain_result/to_err.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { toResultErrFromNullable } from 'option-t/nullable/to_plain_result';
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
 import { nonNullableValueCaseListForSync } from '../../../utils.mjs';
@@ -22,4 +25,11 @@ test(`pass null`, (t) => {
     const actual = toResultErrFromNullable(null);
     t.true(isOk(actual), 'should be Ok(void)');
     t.is(unwrapOk(actual), undefined, 'should the expected result');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.toResultErrFromNullable, toResultErrFromNullable);
+    t.is(NullableRoot.NullableOperator.toResultErr, toResultErrFromNullable);
+    t.is(NullableNamespace.toResultErr, toResultErrFromNullable);
+    t.is(NullableRootCompatV54.toResultErrFromNullable, toResultErrFromNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/to_plain_result/to_ok.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/to_plain_result/to_ok.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { toResultOkFromNullable } from 'option-t/nullable/to_plain_result';
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
 import { nonNullableValueCaseListForSync } from '../../../utils.mjs';
@@ -22,4 +25,11 @@ test(`pass null`, (t) => {
     const actual = toResultOkFromNullable(null);
     t.true(isErr(actual), 'should be Err(void)');
     t.is(unwrapErr(actual), undefined, 'should the expected result');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.toResultOkFromNullable, toResultOkFromNullable);
+    t.is(NullableRoot.NullableOperator.toResultOk, toResultOkFromNullable);
+    t.is(NullableNamespace.toResultOk, toResultOkFromNullable);
+    t.is(NullableRootCompatV54.toResultOkFromNullable, toResultOkFromNullable);
 });

--- a/packages/api_tests/__tests__/nullable/operators/to_undefinable.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/to_undefinable.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { toUndefinableFromNullable } from 'option-t/nullable/to_undefinable';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -16,3 +19,10 @@ for (const NULL_VALUE of [undefined, null]) {
         t.is(actual, undefined);
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.toUndefinableFromNullable, toUndefinableFromNullable);
+    t.is(NullableRoot.NullableOperator.toUndefinable, toUndefinableFromNullable);
+    t.is(NullableNamespace.toUndefinable, toUndefinableFromNullable);
+    t.is(NullableRootCompatV54.toUndefinableFromNullable, toUndefinableFromNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/unwrap_or.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/unwrap_or.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { unwrapOrForNullable } from 'option-t/nullable/unwrap_or';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -44,3 +47,10 @@ for (const [src, def] of testcases) {
         );
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.unwrapOrForNullable, unwrapOrForNullable);
+    t.is(NullableRoot.NullableOperator.unwrapOr, unwrapOrForNullable);
+    t.is(NullableNamespace.unwrapOr, unwrapOrForNullable);
+    t.is(NullableRootCompatV54.unwrapOrForNullable, unwrapOrForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/unwrap_or_else.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/unwrap_or_else.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { unwrapOrElseForNullable } from 'option-t/nullable/unwrap_or_else';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -58,3 +61,10 @@ for (const [src, def] of testcases) {
         );
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.unwrapOrElseForNullable, unwrapOrElseForNullable);
+    t.is(NullableRoot.NullableOperator.unwrapOrElse, unwrapOrElseForNullable);
+    t.is(NullableNamespace.unwrapOrElse, unwrapOrElseForNullable);
+    t.is(NullableRootCompatV54.unwrapOrElseForNullable, unwrapOrElseForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/unwrap_or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/unwrap_or_else_async.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as NullableRoot from 'option-t/nullable';
+import * as NullableRootCompatV54 from 'option-t/nullable/compat/v54';
+import { Nullable as NullableNamespace } from 'option-t/nullable/namespace';
 import { unwrapOrElseAsyncForNullable } from 'option-t/nullable/unwrap_or_else_async';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
@@ -73,3 +76,10 @@ for (const [src, def] of testcases) {
         );
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(NullableRoot.unwrapOrElseAsyncForNullable, unwrapOrElseAsyncForNullable);
+    t.is(NullableRoot.NullableOperator.unwrapOrElseAsync, unwrapOrElseAsyncForNullable);
+    t.is(NullableNamespace.unwrapOrElseAsync, unwrapOrElseAsyncForNullable);
+    t.is(NullableRootCompatV54.unwrapOrElseAsyncForNullable, unwrapOrElseAsyncForNullable);
+});

--- a/packages/api_tests/__tests__/nullable/operators/xor.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/xor.test.mjs
@@ -30,3 +30,7 @@ for (const { a, b, expected } of TABLE) {
         t.is(actual, expected, 'should be `' + String(expected) + '`');
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/nullable/operators/zip.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/zip.test.mjs
@@ -30,3 +30,7 @@ for (const { a, b, expected } of TABLE) {
         t.deepEqual(actual, expected, 'should be `' + String(expected) + '`');
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/nullable/operators/zip_with.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/zip_with.test.mjs
@@ -90,3 +90,7 @@ test(`should throw if the callback return ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) 
         },
     );
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/nullable/operators/zip_with_async.test.mjs
+++ b/packages/api_tests/__tests__/nullable/operators/zip_with_async.test.mjs
@@ -98,3 +98,7 @@ test(`should throw if the callback return ${NULL_VALUE_IN_THIS_TEST_CASE}`, asyn
         },
     );
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});


### PR DESCRIPTION
Fix https://github.com/option-t/option-t/issues/2620