### PR TITLE
plain_result: Add tests to check exported aliases are the expected identity

### DIFF
--- a/packages/api_tests/__tests__/plain_result/core/create.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/core/create.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
 import * as PlainResult from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
+import { createOk, createErr } from 'option-t/plain_result/result';
 
 test('PlainResult::createOk', (t) => {
     const EXPECTED = Symbol('ok');
@@ -16,4 +19,16 @@ test('PlainResult::createErr', (t) => {
 
     t.true(PlainResult.isErr(actual), 'actual should be Err');
     t.is(PlainResult.unwrapErr(actual), EXPECTED, 'actual should be expected');
+});
+
+test(`exported alias' identity check: createOk`, (t) => {
+    t.is(PlainResult.createOk, createOk);
+    t.is(PlainResultNamespace.createOk, createOk);
+    t.is(PlainResultCompatV54.createOk, createOk);
+});
+
+test(`exported alias' identity check: createErr`, (t) => {
+    t.is(PlainResult.createErr, createErr);
+    t.is(PlainResultNamespace.createErr, createErr);
+    t.is(PlainResultCompatV54.createErr, createErr);
 });

--- a/packages/api_tests/__tests__/plain_result/core/expect/test_expect_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/core/expect/test_expect_err.test.mjs
@@ -1,6 +1,14 @@
 import test from 'ava';
 
-import { createOk, createErr, expectErr as expectErrForResult } from 'option-t/plain_result/result';
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
+import {
+    createOk,
+    createErr,
+    expectErr as expectErrForResult,
+    expectErr,
+} from 'option-t/plain_result/result';
 
 test('input=Ok(T), expect=Err(E)', (t) => {
     const NOT_EXPECTED = Symbol('not expected');
@@ -30,4 +38,10 @@ test('input=Err(E), expect=Err(E)', (t) => {
     });
 
     t.is(actual, EXPECTED);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.expectErr, expectErr);
+    t.is(PlainResultNamespace.expectErr, expectErr);
+    t.is(PlainResultCompatV54.expectErr, expectErr);
 });

--- a/packages/api_tests/__tests__/plain_result/core/expect/test_expect_ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/core/expect/test_expect_ok.test.mjs
@@ -1,6 +1,14 @@
 import test from 'ava';
 
-import { createOk, createErr, expectOk as expectOkForResult } from 'option-t/plain_result/result';
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
+import {
+    createOk,
+    createErr,
+    expectOk as expectOkForResult,
+    expectOk,
+} from 'option-t/plain_result/result';
 
 test('input=Ok(T), expect=Ok(T)', (t) => {
     const EXPECTED = Symbol('expected');
@@ -30,4 +38,10 @@ test('input=Err(E), expect=Ok(T)', (t) => {
             message: MSG,
         },
     );
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.expectOk, expectOk);
+    t.is(PlainResultNamespace.expectOk, expectOk);
+    t.is(PlainResultCompatV54.expectOk, expectOk);
 });

--- a/packages/api_tests/__tests__/plain_result/core/is_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/core/is_err.test.mjs
@@ -1,0 +1,12 @@
+import test from 'ava';
+
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
+import { isErr } from 'option-t/plain_result/result';
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isErr, isErr);
+    t.is(PlainResultNamespace.isErr, isErr);
+    t.is(PlainResultCompatV54.isErr, isErr);
+});

--- a/packages/api_tests/__tests__/plain_result/core/is_ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/core/is_ok.test.mjs
@@ -1,0 +1,12 @@
+import test from 'ava';
+
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
+import { isOk } from 'option-t/plain_result/result';
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isOk, isOk);
+    t.is(PlainResultNamespace.isOk, isOk);
+    t.is(PlainResultCompatV54.isOk, isOk);
+});

--- a/packages/api_tests/__tests__/plain_result/core/unwrap/unwrap_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/core/unwrap/unwrap_err.test.mjs
@@ -1,9 +1,13 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
     unwrapErr as unwrapErrFromResult,
+    unwrapErr,
 } from 'option-t/plain_result/result';
 
 const EXPECTED_OK = Symbol('expected_ok');
@@ -25,4 +29,10 @@ test('Ok', (t) => {
 test('Err', (t) => {
     const input = createErr(EXPECTED_ERR);
     t.is(unwrapErrFromResult(input), EXPECTED_ERR);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.unwrapErr, unwrapErr);
+    t.is(PlainResultNamespace.unwrapErr, unwrapErr);
+    t.is(PlainResultCompatV54.unwrapErr, unwrapErr);
 });

--- a/packages/api_tests/__tests__/plain_result/core/unwrap/unwrap_ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/core/unwrap/unwrap_ok.test.mjs
@@ -1,6 +1,14 @@
 import test from 'ava';
 
-import { createOk, createErr, unwrapOk as unwrapOkFromResult } from 'option-t/plain_result/result';
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
+import {
+    createOk,
+    createErr,
+    unwrapOk as unwrapOkFromResult,
+    unwrapOk,
+} from 'option-t/plain_result/result';
 
 const EXPECTED_OK = Symbol('expected_ok');
 const EXPECTED_ERR = Symbol('expected_err');
@@ -21,4 +29,10 @@ test('Err', (t) => {
             message: 'called with `Err`',
         },
     );
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.unwrapOk, unwrapOk);
+    t.is(PlainResultNamespace.unwrapOk, unwrapOk);
+    t.is(PlainResultCompatV54.unwrapOk, unwrapOk);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/and.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/and.test.mjs
@@ -65,3 +65,7 @@ test('a=Err, b=Err', (t) => {
     t.true(isErr(actual), 'should be Err');
     t.is(unwrapErr(actual), EXPECTED, 'should be the inner value');
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/operators/and_then.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/and_then.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
 import { andThenForResult } from 'option-t/plain_result/and_then';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -53,4 +56,11 @@ test('input is Err(E)', (t) => {
     t.is(actual, input);
     t.true(isErr(actual));
     t.is(unwrapErr(actual), ERROR_E);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.andThenForResult, andThenForResult);
+    t.is(PlainResultRoot.ResultOperator.andThen, andThenForResult);
+    t.is(PlainResultNamespace.andThen, andThenForResult);
+    t.is(PlainResultCompatV54.andThenForResult, andThenForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/and_then_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/and_then_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
 import { andThenAsyncForResult } from 'option-t/plain_result/and_then_async';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -62,4 +65,11 @@ test('input is Err(E)', async (t) => {
     t.is(actual, input);
     t.true(isErr(actual));
     t.is(unwrapErr(actual), ERROR_E);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.andThenAsyncForResult, andThenAsyncForResult);
+    t.is(PlainResultRoot.ResultOperator.andThenAsync, andThenAsyncForResult);
+    t.is(PlainResultNamespace.andThenAsync, andThenAsyncForResult);
+    t.is(PlainResultCompatV54.andThenAsyncForResult, andThenAsyncForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/equal.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/equal.test.mjs
@@ -82,3 +82,7 @@ function createTestcaseForSameValue(lhs) {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/operators/flatten.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/flatten.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { flattenForResult } from 'option-t/plain_result/flatten';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -49,4 +52,11 @@ test('this should remove only one nest level', (t) => {
 
     const actual = flattenForResult(input2);
     t.is(actual, input1, `don't unwrap the input recursively`);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.flattenForResult, flattenForResult);
+    t.is(PlainResultRoot.ResultOperator.flatten, flattenForResult);
+    t.is(PlainResultNamespace.flatten, flattenForResult);
+    t.is(PlainResultCompatV54.flattenForResult, flattenForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/from_promise_settled_result.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/from_promise_settled_result.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { fromPromiseSettledResultToResult } from 'option-t/plain_result/from_promise_settled_result';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     isOk,
     isErr,
@@ -43,4 +46,11 @@ test('should throw error if the input is not supported type', async (t) => {
             message: `\`PromiseSettledResult.status=${status}\` is not supported`,
         },
     );
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.fromPromiseSettledResultToResult, fromPromiseSettledResultToResult);
+    t.is(PlainResultRoot.ResultOperator.fromPromiseSettledResult, fromPromiseSettledResultToResult);
+    t.is(PlainResultNamespace.fromPromiseSettledResult, fromPromiseSettledResultToResult);
+    t.is(PlainResultCompatV54.fromPromiseSettledResultToResult, fromPromiseSettledResultToResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/inspect/test_inspect_both.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/inspect/test_inspect_both.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { inspectBothForResult } from 'option-t/plain_result/inspect';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createErr, createOk } from 'option-t/plain_result/result';
 
 test('input is Ok()', (t) => {
@@ -39,4 +42,11 @@ test('input is Err()', (t) => {
     );
 
     t.is(input, actual, 'should be the expect returned');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.inspectBothForResult, inspectBothForResult);
+    t.is(PlainResultRoot.ResultOperator.inspectBoth, inspectBothForResult);
+    t.is(PlainResultNamespace.inspectBoth, inspectBothForResult);
+    t.is(PlainResultCompatV54.inspectBothForResult, inspectBothForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/inspect/test_inspect_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/inspect/test_inspect_err.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { inspectErrForResult } from 'option-t/plain_result/inspect';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createErr, createOk } from 'option-t/plain_result/result';
 
 test('input is Ok()', (t) => {
@@ -25,4 +28,11 @@ test('input is Err()', (t) => {
     });
 
     t.is(input, actual, 'should be the expect returned');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.inspectErrForResult, inspectErrForResult);
+    t.is(PlainResultRoot.ResultOperator.inspectErr, inspectErrForResult);
+    t.is(PlainResultNamespace.inspectErr, inspectErrForResult);
+    t.is(PlainResultCompatV54.inspectErrForResult, inspectErrForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/inspect/test_inspect_ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/inspect/test_inspect_ok.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { inspectOkForResult } from 'option-t/plain_result/inspect';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createErr, createOk } from 'option-t/plain_result/result';
 
 test('input is Ok()', (t) => {
@@ -26,4 +29,11 @@ test('input is Err()', (t) => {
     });
 
     t.is(input, actual, 'should be the expect returned');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.inspectOkForResult, inspectOkForResult);
+    t.is(PlainResultRoot.ResultOperator.inspectOk, inspectOkForResult);
+    t.is(PlainResultNamespace.inspectOk, inspectOkForResult);
+    t.is(PlainResultCompatV54.inspectOkForResult, inspectOkForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/is_err_and/is_err_and.err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/is_err_and/is_err_and.err.test.mjs
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { isErrAndForResult } from 'option-t/plain_result/is_err_and';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createErr } from 'option-t/plain_result/result';
 
 test('input=Err(T), predicate returns true', (t) => {
@@ -28,4 +31,11 @@ test('input=Err(T), predicate returns false', (t) => {
         return false;
     });
     t.false(actual);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isErrAndForResult, isErrAndForResult);
+    t.is(PlainResultRoot.ResultOperator.isErrAnd, isErrAndForResult);
+    t.is(PlainResultNamespace.isErrAnd, isErrAndForResult);
+    t.is(PlainResultCompatV54.isErrAndForResult, isErrAndForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/is_err_and/is_err_and.ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/is_err_and/is_err_and.ok.test.mjs
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { isErrAndForResult } from 'option-t/plain_result/is_err_and';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk } from 'option-t/plain_result/result';
 
 test('input=Ok(T), predicate returns true', (t) => {
@@ -26,4 +29,11 @@ test('input=Ok(T), predicate returns false', (t) => {
         return false;
     });
     t.false(actual);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isErrAndForResult, isErrAndForResult);
+    t.is(PlainResultRoot.ResultOperator.isErrAnd, isErrAndForResult);
+    t.is(PlainResultNamespace.isErrAnd, isErrAndForResult);
+    t.is(PlainResultCompatV54.isErrAndForResult, isErrAndForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/is_err_and/is_err_and_with_ensure_type.err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/is_err_and/is_err_and_with_ensure_type.err.test.mjs
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { isErrAndWithEnsureTypeForResult } from 'option-t/plain_result/is_err_and';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createErr } from 'option-t/plain_result/result';
 
 test('input=Err(T), predicate returns true', (t) => {
@@ -28,4 +31,11 @@ test('input=Err(T), predicate returns false', (t) => {
         return false;
     });
     t.false(actual);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isErrAndWithEnsureTypeForResult, isErrAndWithEnsureTypeForResult);
+    t.is(PlainResultRoot.ResultOperator.isErrAndWithEnsureType, isErrAndWithEnsureTypeForResult);
+    t.is(PlainResultNamespace.isErrAndWithEnsureType, isErrAndWithEnsureTypeForResult);
+    t.is(PlainResultCompatV54.isErrAndWithEnsureTypeForResult, isErrAndWithEnsureTypeForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/is_err_and/is_err_and_with_ensure_type.ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/is_err_and/is_err_and_with_ensure_type.ok.test.mjs
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { isErrAndWithEnsureTypeForResult } from 'option-t/plain_result/is_err_and';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk } from 'option-t/plain_result/result';
 
 test('input=Ok(T), predicate returns true', (t) => {
@@ -26,4 +29,11 @@ test('input=Ok(T), predicate returns false', (t) => {
         return false;
     });
     t.false(actual);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isErrAndWithEnsureTypeForResult, isErrAndWithEnsureTypeForResult);
+    t.is(PlainResultRoot.ResultOperator.isErrAndWithEnsureType, isErrAndWithEnsureTypeForResult);
+    t.is(PlainResultNamespace.isErrAndWithEnsureType, isErrAndWithEnsureTypeForResult);
+    t.is(PlainResultCompatV54.isErrAndWithEnsureTypeForResult, isErrAndWithEnsureTypeForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/is_ok_and/is_ok_and.err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/is_ok_and/is_ok_and.err.test.mjs
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { isOkAndForResult } from 'option-t/plain_result/is_ok_and';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createErr } from 'option-t/plain_result/result';
 
 test('input=Err(T), predicate returns true', (t) => {
@@ -26,4 +29,11 @@ test('input=Err(T), predicate returns false', (t) => {
         return false;
     });
     t.false(actual);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isOkAndForResult, isOkAndForResult);
+    t.is(PlainResultRoot.ResultOperator.isOkAnd, isOkAndForResult);
+    t.is(PlainResultNamespace.isOkAnd, isOkAndForResult);
+    t.is(PlainResultCompatV54.isOkAndForResult, isOkAndForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/is_ok_and/is_ok_and.ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/is_ok_and/is_ok_and.ok.test.mjs
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { isOkAndForResult } from 'option-t/plain_result/is_ok_and';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk } from 'option-t/plain_result/result';
 
 test('input=Ok(T), predicate returns true', (t) => {
@@ -28,4 +31,11 @@ test('input=Ok(T), predicate returns false', (t) => {
         return false;
     });
     t.false(actual);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isOkAndForResult, isOkAndForResult);
+    t.is(PlainResultRoot.ResultOperator.isOkAnd, isOkAndForResult);
+    t.is(PlainResultNamespace.isOkAnd, isOkAndForResult);
+    t.is(PlainResultCompatV54.isOkAndForResult, isOkAndForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/is_ok_and/is_ok_and_with_ensure_type.err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/is_ok_and/is_ok_and_with_ensure_type.err.test.mjs
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { isOkAndWithEnsureTypeForResult } from 'option-t/plain_result/is_ok_and';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createErr } from 'option-t/plain_result/result';
 
 test('input=Err(T), predicate returns true', (t) => {
@@ -26,4 +29,11 @@ test('input=Err(T), predicate returns false', (t) => {
         return false;
     });
     t.false(actual);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isOkAndWithEnsureTypeForResult, isOkAndWithEnsureTypeForResult);
+    t.is(PlainResultRoot.ResultOperator.isOkAndWithEnsureType, isOkAndWithEnsureTypeForResult);
+    t.is(PlainResultNamespace.isOkAndWithEnsureType, isOkAndWithEnsureTypeForResult);
+    t.is(PlainResultCompatV54.isOkAndWithEnsureTypeForResult, isOkAndWithEnsureTypeForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/is_ok_and/is_ok_and_with_ensure_type.ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/is_ok_and/is_ok_and_with_ensure_type.ok.test.mjs
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { isOkAndWithEnsureTypeForResult } from 'option-t/plain_result/is_ok_and';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk } from 'option-t/plain_result/result';
 
 test('input=Ok(T), predicate returns true', (t) => {
@@ -28,4 +31,11 @@ test('input=Ok(T), predicate returns false', (t) => {
         return false;
     });
     t.false(actual);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.isOkAndWithEnsureTypeForResult, isOkAndWithEnsureTypeForResult);
+    t.is(PlainResultRoot.ResultOperator.isOkAndWithEnsureType, isOkAndWithEnsureTypeForResult);
+    t.is(PlainResultNamespace.isOkAndWithEnsureType, isOkAndWithEnsureTypeForResult);
+    t.is(PlainResultCompatV54.isOkAndWithEnsureTypeForResult, isOkAndWithEnsureTypeForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/map.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/map.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { mapForResult } from 'option-t/plain_result/map';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -40,4 +43,11 @@ test('input is Err(E)', (t) => {
     t.is(actual, input);
     t.true(isErr(actual));
     t.is(unwrapErr(actual), ERROR_E);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.mapForResult, mapForResult);
+    t.is(PlainResultRoot.ResultOperator.map, mapForResult);
+    t.is(PlainResultNamespace.map, mapForResult);
+    t.is(PlainResultCompatV54.mapForResult, mapForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/map_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/map_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { mapAsyncForResult } from 'option-t/plain_result/map_async';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -46,4 +49,11 @@ test('input is Err(E)', async (t) => {
     t.is(actual, input);
     t.true(isErr(actual));
     t.is(unwrapErr(actual), ERROR_E);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.mapAsyncForResult, mapAsyncForResult);
+    t.is(PlainResultRoot.ResultOperator.mapAsync, mapAsyncForResult);
+    t.is(PlainResultNamespace.mapAsync, mapAsyncForResult);
+    t.is(PlainResultCompatV54.mapAsyncForResult, mapAsyncForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/map_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/map_err.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { mapErrForResult } from 'option-t/plain_result/map_err';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -40,4 +43,11 @@ test('input is Err(E)', (t) => {
     t.not(actual, input);
     t.true(isErr(actual));
     t.is(unwrapErr(actual), ERROR_F);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.mapErrForResult, mapErrForResult);
+    t.is(PlainResultRoot.ResultOperator.mapErr, mapErrForResult);
+    t.is(PlainResultNamespace.mapErr, mapErrForResult);
+    t.is(PlainResultCompatV54.mapErrForResult, mapErrForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/map_err_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/map_err_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { mapErrAsyncForResult } from 'option-t/plain_result/map_err_async';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -46,4 +49,11 @@ test('input is Err(E)', async (t) => {
     t.not(actual, input);
     t.true(isErr(actual));
     t.is(unwrapErr(actual), ERROR_F);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.mapErrAsyncForResult, mapErrAsyncForResult);
+    t.is(PlainResultRoot.ResultOperator.mapErrAsync, mapErrAsyncForResult);
+    t.is(PlainResultNamespace.mapErrAsync, mapErrAsyncForResult);
+    t.is(PlainResultCompatV54.mapErrAsyncForResult, mapErrAsyncForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/map_or.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/map_or.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { mapOrForResult } from 'option-t/plain_result/map_or';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 
 test('Ok<T>', (t) => {
@@ -31,4 +34,11 @@ test('Err<E>', (t) => {
     });
 
     t.is(r, EXPECTED, 'the return value');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.mapOrForResult, mapOrForResult);
+    t.is(PlainResultRoot.ResultOperator.mapOr, mapOrForResult);
+    t.is(PlainResultNamespace.mapOr, mapOrForResult);
+    t.is(PlainResultCompatV54.mapOrForResult, mapOrForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/map_or_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/map_or_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { mapOrAsyncForResult } from 'option-t/plain_result/map_or_async';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 
 test('Ok<T>', async (t) => {
@@ -37,4 +40,11 @@ test('Err<E>', async (t) => {
 
     const actual = await result;
     t.is(actual, EXPECTED, 'the return value');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.mapOrAsyncForResult, mapOrAsyncForResult);
+    t.is(PlainResultRoot.ResultOperator.mapOrAsync, mapOrAsyncForResult);
+    t.is(PlainResultNamespace.mapOrAsync, mapOrAsyncForResult);
+    t.is(PlainResultCompatV54.mapOrAsyncForResult, mapOrAsyncForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/map_or_else.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/map_or_else.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { mapOrElseForResult } from 'option-t/plain_result/map_or_else';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 
 const PLAN_COUNT = 2;
@@ -45,4 +48,11 @@ test('Err<E>', (t) => {
     );
 
     t.is(r, 3, 'the return value');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.mapOrElseForResult, mapOrElseForResult);
+    t.is(PlainResultRoot.ResultOperator.mapOrElse, mapOrElseForResult);
+    t.is(PlainResultNamespace.mapOrElse, mapOrElseForResult);
+    t.is(PlainResultCompatV54.mapOrElseForResult, mapOrElseForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/map_or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/map_or_else_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
 import { mapOrElseAsyncForResult } from 'option-t/plain_result/map_or_else_async';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 
 const PLAN_COUNT = 3;
@@ -51,4 +54,11 @@ test('Err<E>', async (t) => {
 
     const actual = await result;
     t.is(actual, 3, 'the return value');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.mapOrElseAsyncForResult, mapOrElseAsyncForResult);
+    t.is(PlainResultRoot.ResultOperator.mapOrElseAsync, mapOrElseAsyncForResult);
+    t.is(PlainResultNamespace.mapOrElseAsync, mapOrElseAsyncForResult);
+    t.is(PlainResultCompatV54.mapOrElseAsyncForResult, mapOrElseAsyncForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/or.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/or.test.mjs
@@ -65,3 +65,7 @@ test('a=Err, b=Err', (t) => {
     t.true(isErr(actual), 'should be Err');
     t.is(unwrapErr(actual), EXPECTED, 'should be the inner value');
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/operators/or_else.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/or_else.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { orElseForResult } from 'option-t/plain_result/or_else';
 import { createOk, createErr } from 'option-t/plain_result/result';
 
@@ -43,4 +46,11 @@ test('input is Err(E), callback return Err(F)', (t) => {
         return expected;
     });
     t.is(actual, expected);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.orElseForResult, orElseForResult);
+    t.is(PlainResultRoot.ResultOperator.orElse, orElseForResult);
+    t.is(PlainResultNamespace.orElse, orElseForResult);
+    t.is(PlainResultCompatV54.orElseForResult, orElseForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/or_else_async.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { orElseAsyncForResult } from 'option-t/plain_result/or_else_async';
 import { createOk, createErr } from 'option-t/plain_result/result';
 
@@ -54,4 +57,11 @@ test('input is Err(E), callback return Err(F)', async (t) => {
 
     const actual = await result;
     t.is(actual, expected);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.orElseAsyncForResult, orElseAsyncForResult);
+    t.is(PlainResultRoot.ResultOperator.orElseAsync, orElseAsyncForResult);
+    t.is(PlainResultNamespace.orElseAsync, orElseAsyncForResult);
+    t.is(PlainResultCompatV54.orElseAsyncForResult, orElseAsyncForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/to_nullable/from_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/to_nullable/from_err.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { toNullableFromErr } from 'option-t/plain_result/to_nullable';
 
@@ -16,4 +19,11 @@ test('input is Err(E)', (t) => {
     const input = createErr(ERROR_E);
     const actual = toNullableFromErr(input);
     t.is(actual, ERROR_E);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.toNullableFromErr, toNullableFromErr);
+    t.is(PlainResultRoot.ResultOperator.toNullableFromErr, toNullableFromErr);
+    t.is(PlainResultNamespace.toNullableFromErr, toNullableFromErr);
+    t.is(PlainResultCompatV54.toNullableFromErr, toNullableFromErr);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/to_nullable/from_ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/to_nullable/from_ok.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { toNullableFromOk } from 'option-t/plain_result/to_nullable';
 
@@ -16,4 +19,11 @@ test('input is Err(E)', (t) => {
     const input = createErr(ERROR_E);
     const actual = toNullableFromOk(input);
     t.is(actual, null);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.toNullableFromOk, toNullableFromOk);
+    t.is(PlainResultRoot.ResultOperator.toNullableFromOk, toNullableFromOk);
+    t.is(PlainResultNamespace.toNullableFromOk, toNullableFromOk);
+    t.is(PlainResultCompatV54.toNullableFromOk, toNullableFromOk);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/to_undefinable/from_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/to_undefinable/from_err.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { toUndefinableFromErr } from 'option-t/plain_result/to_undefinable';
 
@@ -16,4 +19,11 @@ test('input is Err(E)', (t) => {
     const input = createErr(ERROR_E);
     const actual = toUndefinableFromErr(input);
     t.is(actual, ERROR_E);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.toUndefinableFromErr, toUndefinableFromErr);
+    t.is(PlainResultRoot.ResultOperator.toUndefinableFromErr, toUndefinableFromErr);
+    t.is(PlainResultNamespace.toUndefinableFromErr, toUndefinableFromErr);
+    t.is(PlainResultCompatV54.toUndefinableFromErr, toUndefinableFromErr);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/to_undefinable/from_ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/to_undefinable/from_ok.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { toUndefinableFromOk } from 'option-t/plain_result/to_undefinable';
 
@@ -16,4 +19,11 @@ test('input is Err(E)', (t) => {
     const input = createErr(ERROR_E);
     const actual = toUndefinableFromOk(input);
     t.is(actual, undefined);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.toUndefinableFromOk, toUndefinableFromOk);
+    t.is(PlainResultRoot.ResultOperator.toUndefinableFromOk, toUndefinableFromOk);
+    t.is(PlainResultNamespace.toUndefinableFromOk, toUndefinableFromOk);
+    t.is(PlainResultCompatV54.toUndefinableFromOk, toUndefinableFromOk);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/transpose/to_nullable.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/transpose/to_nullable.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -31,4 +34,11 @@ test('input is Err<E>, the result should be Err(e)', (t) => {
 
     t.true(isErr(actual), 'the actual should Err<E>');
     t.is(unwrapErr(actual), inner, "the actual's inner should E");
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.transposeResultToNullable, transposeResultToNullable);
+    t.is(PlainResultRoot.ResultOperator.transposeToNullable, transposeResultToNullable);
+    t.is(PlainResultNamespace.transposeToNullable, transposeResultToNullable);
+    t.is(PlainResultCompatV54.transposeResultToNullable, transposeResultToNullable);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/transpose/to_undefinable.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/transpose/to_undefinable.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     createOk,
     createErr,
@@ -31,4 +34,11 @@ test('input is Err<E>, the result should be Err(e)', (t) => {
 
     t.true(isErr(actual), 'the actual should Err<E>');
     t.is(unwrapErr(actual), inner, "the actual's inner should E");
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.transposeResultToUndefinable, transposeResultToUndefinable);
+    t.is(PlainResultRoot.ResultOperator.transposeToUndefinable, transposeResultToUndefinable);
+    t.is(PlainResultNamespace.transposeToUndefinable, transposeResultToUndefinable);
+    t.is(PlainResultCompatV54.transposeResultToUndefinable, transposeResultToUndefinable);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch/try_catch.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch/try_catch.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     isOk,
     isErr,
@@ -32,4 +35,11 @@ test('output=Err(unknown)', (t) => {
 
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErrFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.tryCatchIntoResult, tryCatchIntoResult);
+    t.is(PlainResultRoot.ResultOperator.tryCatchInto, tryCatchIntoResult);
+    t.is(PlainResultNamespace.tryCatchInto, tryCatchIntoResult);
+    t.is(PlainResultCompatV54.tryCatchIntoResult, tryCatchIntoResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch/try_catch_with_assert_error.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch/try_catch_with_assert_error.test.mjs
@@ -85,3 +85,7 @@ test('If producer throw the instance value from cross-realm `Error` constructor'
     // assert
     t.is(actual.cause, EXPECT_THROWN, `should set Error.cause`);
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch/try_catch_with_ensure_error.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch/try_catch_with_ensure_error.test.mjs
@@ -1,6 +1,9 @@
 import { webcrypto } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
 import { tryCatchIntoResultWithEnsureError } from 'option-t/plain_result/try_catch';
 import { getCrossRealmErrorConstructor } from '../../../cross_realm_error_helper.mjs';
@@ -112,4 +115,14 @@ test('If producer throw the instance value of cross-realm `Error` constructor', 
         );
         t.is(actual.cause, EXPECT_THROWN, '.cause should hold the expect inner value');
     }
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.tryCatchIntoResultWithEnsureError, tryCatchIntoResultWithEnsureError);
+    t.is(
+        PlainResultRoot.ResultOperator.tryCatchIntoWithEnsureError,
+        tryCatchIntoResultWithEnsureError,
+    );
+    t.is(PlainResultNamespace.tryCatchIntoWithEnsureError, tryCatchIntoResultWithEnsureError);
+    t.is(PlainResultCompatV54.tryCatchIntoResultWithEnsureError, tryCatchIntoResultWithEnsureError);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_async/producer_is_async_fn.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_async/producer_is_async_fn.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     isOk,
     isErr,
@@ -38,4 +41,11 @@ test('output=Err(unknown): producer is async fn', async (t) => {
     const actual = await result;
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErrFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.tryCatchIntoResultAsync, tryCatchIntoResultAsync);
+    t.is(PlainResultRoot.ResultOperator.tryCatchIntoAsync, tryCatchIntoResultAsync);
+    t.is(PlainResultNamespace.tryCatchIntoAsync, tryCatchIntoResultAsync);
+    t.is(PlainResultCompatV54.tryCatchIntoResultAsync, tryCatchIntoResultAsync);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_async/producer_is_normal_fn.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_async/producer_is_normal_fn.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import {
     isOk,
     isErr,
@@ -55,4 +58,11 @@ test('output=Err(unknown): producer is normal fn but throw an error before retur
     const actual = await result;
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErrFromResult(actual), EXPECTED, 'should contain the expect inner value');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.tryCatchIntoResultAsync, tryCatchIntoResultAsync);
+    t.is(PlainResultRoot.ResultOperator.tryCatchIntoAsync, tryCatchIntoResultAsync);
+    t.is(PlainResultNamespace.tryCatchIntoAsync, tryCatchIntoResultAsync);
+    t.is(PlainResultCompatV54.tryCatchIntoResultAsync, tryCatchIntoResultAsync);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_with_assert_error_async/producer_is_async_fn.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_with_assert_error_async/producer_is_async_fn.test.mjs
@@ -91,3 +91,7 @@ test('if producer is async function and throw a instance value from cross-realm 
 
     t.is(actual.cause, THROWN_EXPECTED, 'should set Error.cause');
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_with_assert_error_async/producer_is_normal_fn.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_with_assert_error_async/producer_is_normal_fn.test.mjs
@@ -130,3 +130,7 @@ test('if producer is normal function and throw a instance value from cross-realm
 
     t.is(actual.cause, THROWN_EXPECTED, 'should set Error.cause');
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_with_ensure_error_async/producer_is_async_fn.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_with_ensure_error_async/producer_is_async_fn.test.mjs
@@ -1,6 +1,10 @@
 import { webcrypto } from 'node:crypto';
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import { ResultOperator } from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
 import { tryCatchIntoResultWithEnsureErrorAsync } from 'option-t/plain_result/try_catch_async';
 import { getCrossRealmErrorConstructor } from '../../../../cross_realm_error_helper.mjs';
@@ -119,4 +123,20 @@ test('if producer is async function and throw a instance value from cross-realm 
         );
         t.is(actual.cause, EXPECT_THROWN, '.cause should hold the expect inner value');
     }
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(
+        PlainResultRoot.tryCatchIntoResultWithEnsureErrorAsync,
+        tryCatchIntoResultWithEnsureErrorAsync,
+    );
+    t.is(ResultOperator.tryCatchIntoWithEnsureErrorAsync, tryCatchIntoResultWithEnsureErrorAsync);
+    t.is(
+        PlainResultNamespace.tryCatchIntoWithEnsureErrorAsync,
+        tryCatchIntoResultWithEnsureErrorAsync,
+    );
+    t.is(
+        PlainResultCompatV54.tryCatchIntoResultWithEnsureErrorAsync,
+        tryCatchIntoResultWithEnsureErrorAsync,
+    );
 });

--- a/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_with_ensure_error_async/producer_is_normal_fn.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/try_catch_async/try_catch_with_ensure_error_async/producer_is_normal_fn.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
 import { tryCatchIntoResultWithEnsureErrorAsync } from 'option-t/plain_result/try_catch_async';
 import { getCrossRealmErrorConstructor } from '../../../../cross_realm_error_helper.mjs';
@@ -213,4 +216,23 @@ test('if producer is normal function and throw a instance value from cross-realm
         );
         t.is(actual.cause, THROWN_EXPECTED, '.cause should hold the expect inner value');
     }
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(
+        PlainResultRoot.tryCatchIntoResultWithEnsureErrorAsync,
+        tryCatchIntoResultWithEnsureErrorAsync,
+    );
+    t.is(
+        PlainResultRoot.ResultOperator.tryCatchIntoWithEnsureErrorAsync,
+        tryCatchIntoResultWithEnsureErrorAsync,
+    );
+    t.is(
+        PlainResultNamespace.tryCatchIntoWithEnsureErrorAsync,
+        tryCatchIntoResultWithEnsureErrorAsync,
+    );
+    t.is(
+        PlainResultCompatV54.tryCatchIntoResultWithEnsureErrorAsync,
+        tryCatchIntoResultWithEnsureErrorAsync,
+    );
 });

--- a/packages/api_tests/__tests__/plain_result/operators/unwrap_or/ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/unwrap_or/ok.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { unwrapOrForResult } from 'option-t/plain_result/unwrap_or';
 
@@ -17,4 +20,11 @@ test('input is Err(E)', (t) => {
     const input = createErr(ERROR_E);
     const actual = unwrapOrForResult(input, DEFAULT_VAL);
     t.is(actual, DEFAULT_VAL);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.unwrapOrForResult, unwrapOrForResult);
+    t.is(PlainResultRoot.ResultOperator.unwrapOr, unwrapOrForResult);
+    t.is(PlainResultNamespace.unwrapOr, unwrapOrForResult);
+    t.is(PlainResultCompatV54.unwrapOrForResult, unwrapOrForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/unwrap_or_else.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/unwrap_or_else.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { unwrapOrElseForResult } from 'option-t/plain_result/unwrap_or_else';
 
@@ -27,4 +30,11 @@ test('input is Err(E)', (t) => {
         return DEFAULT_VAL;
     });
     t.is(actual, DEFAULT_VAL);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.unwrapOrElseForResult, unwrapOrElseForResult);
+    t.is(PlainResultRoot.ResultOperator.unwrapOrElse, unwrapOrElseForResult);
+    t.is(PlainResultNamespace.unwrapOrElse, unwrapOrElseForResult);
+    t.is(PlainResultCompatV54.unwrapOrElseForResult, unwrapOrElseForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/unwrap_or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/unwrap_or_else_async.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { unwrapOrElseAsyncForResult } from 'option-t/plain_result/unwrap_or_else_async';
 
@@ -35,4 +38,11 @@ test('input is Err(E)', async (t) => {
 
     const actual = await result;
     t.is(actual, DEFAULT_VAL);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.unwrapOrElseAsyncForResult, unwrapOrElseAsyncForResult);
+    t.is(PlainResultRoot.ResultOperator.unwrapOrElseAsync, unwrapOrElseAsyncForResult);
+    t.is(PlainResultNamespace.unwrapOrElseAsync, unwrapOrElseAsyncForResult);
+    t.is(PlainResultCompatV54.unwrapOrElseAsyncForResult, unwrapOrElseAsyncForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/unwrap_or_throw/throw_error_with_assert.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/unwrap_or_throw/throw_error_with_assert.test.mjs
@@ -74,3 +74,7 @@ test('input is Err, but the contained value is not an `Error` instance of curren
 
     t.is(thrown.cause, ERROR_E, `should be set Error.cause`);
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/operators/unwrap_or_throw/throw_error_with_wrapping.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/unwrap_or_throw/throw_error_with_wrapping.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as PlainResultRoot from 'option-t/plain_result';
+import * as PlainResultCompatV54 from 'option-t/plain_result/compat/v54';
+import { Result as PlainResultNamespace } from 'option-t/plain_result/namespace';
 import { createOk, createErr } from 'option-t/plain_result/result';
 import { unwrapOrThrowForResult } from 'option-t/plain_result/unwrap_or_throw';
 
@@ -50,4 +53,11 @@ test('input is Err(non Error instance)', (t) => {
     t.not(thrown, ERROR_E, 'should generate a new error instance');
     t.is(thrown.name, 'CausalCarrierError', 'should be expected Error.name');
     t.is(thrown.cause, ERROR_E, '.cause should be set properly');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(PlainResultRoot.unwrapOrThrowForResult, unwrapOrThrowForResult);
+    t.is(PlainResultRoot.ResultOperator.unwrapOrThrow, unwrapOrThrowForResult);
+    t.is(PlainResultNamespace.unwrapOrThrow, unwrapOrThrowForResult);
+    t.is(PlainResultCompatV54.unwrapOrThrowForResult, unwrapOrThrowForResult);
 });

--- a/packages/api_tests/__tests__/plain_result/operators/unwrap_or_throw/throw_unknown.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/operators/unwrap_or_throw/throw_unknown.test.mjs
@@ -39,3 +39,7 @@ test('input is Err(not Error instance)', (t) => {
         t.is(e, ERROR_E);
     }
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/unsafe/as_mut.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/unsafe/as_mut.test.mjs
@@ -35,3 +35,7 @@ for (const [typename, inputValue] of TEST_CASE_LIST) {
         );
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/unsafe/drop/test_drop_both.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/unsafe/drop/test_drop_both.test.mjs
@@ -87,3 +87,7 @@ test('should throw if the passed value is frozen: Err', (t) => {
         },
     );
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/unsafe/drop/test_drop_err.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/unsafe/drop/test_drop_err.test.mjs
@@ -60,3 +60,7 @@ test('should throw if the passed value is frozen: Err', (t) => {
         },
     );
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/plain_result/unsafe/drop/test_drop_ok.test.mjs
+++ b/packages/api_tests/__tests__/plain_result/unsafe/drop/test_drop_ok.test.mjs
@@ -60,3 +60,7 @@ test('should throw if the passed value is frozen: Err', (t) => {
         },
     );
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});


### PR DESCRIPTION
Fix https://github.com/option-t/option-t/issues/2624