### PR TITLE
undefinable: Add tests to check exported aliases are the expected identity

### DIFF
--- a/packages/api_tests/__tests__/undefinable/core/expect.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/core/expect.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { expectNotUndefined } from 'option-t/undefinable/undefinable';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -45,4 +48,10 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
             message: EXPECTED_MSG,
         },
     );
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.expectNotUndefined, expectNotUndefined);
+    t.is(UndefinableNamespace.expectNotUndefined, expectNotUndefined);
+    t.is(UndefinableRootCompatV54.expectNotUndefined, expectNotUndefined);
 });

--- a/packages/api_tests/__tests__/undefinable/core/is_not_undefined.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/core/is_not_undefined.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
-import * as Undefinable from 'option-t/undefinable';
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
+import { isNotUndefined } from 'option-t/undefinable/undefinable';
 
 test('Undefinable::isNotUndefined', (t) => {
     const testcase = [
@@ -22,9 +25,15 @@ test('Undefinable::isNotUndefined', (t) => {
         const expected = test[1];
 
         t.is(
-            Undefinable.isNotUndefined(input),
+            isNotUndefined(input),
             expected,
             `\`${String(input)}\` should be \`${String(expected)}\``,
         );
     });
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.isNotUndefined, isNotUndefined);
+    t.is(UndefinableNamespace.isNotUndefined, isNotUndefined);
+    t.is(UndefinableRootCompatV54.isNotUndefined, isNotUndefined);
 });

--- a/packages/api_tests/__tests__/undefinable/core/is_undefined.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/core/is_undefined.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
-import * as Undefinable from 'option-t/undefinable';
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
+import { isUndefined } from 'option-t/undefinable/undefinable';
 
 test('Undefinable::isUndefined', (t) => {
     const testcase = [
@@ -22,9 +25,15 @@ test('Undefinable::isUndefined', (t) => {
         const expected = test[1];
 
         t.is(
-            Undefinable.isUndefined(input),
+            isUndefined(input),
             expected,
             `\`${String(input)}\` should be \`${String(expected)}\``,
         );
     });
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.isUndefined, isUndefined);
+    t.is(UndefinableNamespace.isUndefined, isUndefined);
+    t.is(UndefinableRootCompatV54.isUndefined, isUndefined);
 });

--- a/packages/api_tests/__tests__/undefinable/core/unwrap.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/core/unwrap.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { unwrapUndefinable } from 'option-t/undefinable/undefinable';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -42,4 +45,10 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
             message: 'called with `undefined`',
         },
     );
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.unwrapUndefinable, unwrapUndefinable);
+    t.is(UndefinableNamespace.unwrapUndefinable, unwrapUndefinable);
+    t.is(UndefinableRootCompatV54.unwrapUndefinable, unwrapUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/and.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/and.test.mjs
@@ -37,3 +37,7 @@ test('Undefinable::and', (t) => {
         t.is(andForUndefinable(a, b), expected, `a=${String(a)}, b=${String(b)}`);
     }
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/and_then.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/and_then.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
 import { andThenForUndefinable } from 'option-t/undefinable/and_then';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -42,4 +45,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
     });
 
     t.is(result, NULL_VALUE_IN_THIS_TEST_CASE, 'should be the expected result');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.andThenForUndefinable, andThenForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.andThen, andThenForUndefinable);
+    t.is(UndefinableNamespace.andThen, andThenForUndefinable);
+    t.is(UndefinableRootCompatV54.andThenForUndefinable, andThenForUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/and_then_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/and_then_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
 import { andThenAsyncForUndefinable } from 'option-t/undefinable/and_then_async';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -52,4 +55,11 @@ test('pass undefined', async (t) => {
 
     const actual = await result;
     t.is(actual, NULL_VALUE_IN_THIS_TEST_CASE, 'should be the expected result');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.andThenAsyncForUndefinable, andThenAsyncForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.andThenAsync, andThenAsyncForUndefinable);
+    t.is(UndefinableNamespace.andThenAsync, andThenAsyncForUndefinable);
+    t.is(UndefinableRootCompatV54.andThenAsyncForUndefinable, andThenAsyncForUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/filter/filter.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/filter/filter.test.mjs
@@ -33,3 +33,7 @@ test('input is undefined', (t) => {
     });
     t.is(actual, undefined);
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/filter/filter_with_ensure_type.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/filter/filter_with_ensure_type.test.mjs
@@ -33,3 +33,7 @@ test('input is undefined', (t) => {
     });
     t.is(actual, undefined);
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/filter_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/filter_async.test.mjs
@@ -31,3 +31,7 @@ test('input is undefined', async (t) => {
     });
     t.is(actual, undefined);
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/inspect.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/inspect.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
 import { inspectUndefinable } from 'option-t/undefinable/inspect';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -37,4 +40,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
     });
 
     t.is(result, NULL_VALUE_IN_THIS_TEST_CASE, 'should be input');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.inspectUndefinable, inspectUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.inspect, inspectUndefinable);
+    t.is(UndefinableNamespace.inspect, inspectUndefinable);
+    t.is(UndefinableRootCompatV54.inspectUndefinable, inspectUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/map.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/map.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
 import { mapForUndefinable } from 'option-t/undefinable/map';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -53,3 +56,10 @@ test('pass undefined', (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.mapForUndefinable, mapForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.map, mapForUndefinable);
+    t.is(UndefinableNamespace.map, mapForUndefinable);
+    t.is(UndefinableRootCompatV54.mapForUndefinable, mapForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/map_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/map_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
 import { mapAsyncForUndefinable } from 'option-t/undefinable/map_async';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -67,3 +70,10 @@ for (const [src, def] of testcases) {
         );
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.mapAsyncForUndefinable, mapAsyncForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.mapAsync, mapAsyncForUndefinable);
+    t.is(UndefinableNamespace.mapAsync, mapAsyncForUndefinable);
+    t.is(UndefinableRootCompatV54.mapAsyncForUndefinable, mapAsyncForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/map_or.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/map_or.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
 import { mapOrForUndefinable } from 'option-t/undefinable/map_or';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -88,3 +91,10 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.mapOrForUndefinable, mapOrForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.mapOr, mapOrForUndefinable);
+    t.is(UndefinableNamespace.mapOr, mapOrForUndefinable);
+    t.is(UndefinableRootCompatV54.mapOrForUndefinable, mapOrForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/map_or_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/map_or_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
 import { mapOrAsyncForUndefinable } from 'option-t/undefinable/map_or_async';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -110,3 +113,10 @@ test('pass undefined', async (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.mapOrAsyncForUndefinable, mapOrAsyncForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.mapOrAsync, mapOrAsyncForUndefinable);
+    t.is(UndefinableNamespace.mapOrAsync, mapOrAsyncForUndefinable);
+    t.is(UndefinableRootCompatV54.mapOrAsyncForUndefinable, mapOrAsyncForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/map_or_else.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/map_or_else.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
 import { mapOrElseForUndefinable } from 'option-t/undefinable/map_or_else';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -112,3 +115,10 @@ test('pass undefined', (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.mapOrElseForUndefinable, mapOrElseForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.mapOrElse, mapOrElseForUndefinable);
+    t.is(UndefinableNamespace.mapOrElse, mapOrElseForUndefinable);
+    t.is(UndefinableRootCompatV54.mapOrElseForUndefinable, mapOrElseForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/map_or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/map_or_else_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
 import { mapOrElseAsyncForUndefinable } from 'option-t/undefinable/map_or_else_async';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
 const NULL_VALUE_IN_THIS_TEST_CASE = undefined;
@@ -138,3 +141,10 @@ test('pass undefined', async (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.mapOrElseAsyncForUndefinable, mapOrElseAsyncForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.mapOrElseAsync, mapOrElseAsyncForUndefinable);
+    t.is(UndefinableNamespace.mapOrElseAsync, mapOrElseAsyncForUndefinable);
+    t.is(UndefinableRootCompatV54.mapOrElseAsyncForUndefinable, mapOrElseAsyncForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/ok_or.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/ok_or.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { okOrForUndefinable } from 'option-t/undefinable/ok_or';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -41,4 +44,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
 
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErr(actual), DEFAULT_ERR, 'should contain the expected');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.okOrForUndefinable, okOrForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.okOr, okOrForUndefinable);
+    t.is(UndefinableNamespace.okOr, okOrForUndefinable);
+    t.is(UndefinableRootCompatV54.okOrForUndefinable, okOrForUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/ok_or_else.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/ok_or_else.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { okOrElseForUndefinable } from 'option-t/undefinable/ok_or_else';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -48,4 +51,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
 
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErr(actual), DEFAULT_ERR, 'should contain the expected');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.okOrElseForUndefinable, okOrElseForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.okOrElse, okOrElseForUndefinable);
+    t.is(UndefinableNamespace.okOrElse, okOrElseForUndefinable);
+    t.is(UndefinableRootCompatV54.okOrElseForUndefinable, okOrElseForUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/ok_or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/ok_or_else_async.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { okOrElseAsyncForUndefinable } from 'option-t/undefinable/ok_or_else_async';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -57,4 +60,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, async (t) => {
     const actual = await result;
     t.true(isErr(actual), 'should be Err(E)');
     t.is(unwrapErr(actual), DEFAULT_ERR, 'should contain the expected');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.okOrElseAsyncForUndefinable, okOrElseAsyncForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.okOrElseAsync, okOrElseAsyncForUndefinable);
+    t.is(UndefinableNamespace.okOrElseAsync, okOrElseAsyncForUndefinable);
+    t.is(UndefinableRootCompatV54.okOrElseAsyncForUndefinable, okOrElseAsyncForUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/or.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/or.test.mjs
@@ -37,3 +37,7 @@ test('Undefinable::or', (t) => {
         t.is(orForUndefinable(a, b), expected, `a=${String(a)}, b=${String(b)}`);
     }
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/or_else.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/or_else.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { orElseForUndefinable } from 'option-t/undefinable/or_else';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -40,4 +43,11 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
     });
 
     t.is(result, DEFAULT_VAL, 'should be the default');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.orElseForUndefinable, orElseForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.orElse, orElseForUndefinable);
+    t.is(UndefinableNamespace.orElse, orElseForUndefinable);
+    t.is(UndefinableRootCompatV54.orElseForUndefinable, orElseForUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/or_else_async.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { orElseAsyncForUndefinable } from 'option-t/undefinable/or_else_async';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
@@ -53,4 +56,11 @@ test(`pass ${NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE}`, async (t) => {
     t.true(result instanceof Promise, 'result should be Promise');
     const actual = await result;
     t.is(actual, NULLY_VALUE_BUT_NOT_NULL_VALUE_IN_THIS_TEST_CASE);
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.orElseAsyncForUndefinable, orElseAsyncForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.orElseAsync, orElseAsyncForUndefinable);
+    t.is(UndefinableNamespace.orElseAsync, orElseAsyncForUndefinable);
+    t.is(UndefinableRootCompatV54.orElseAsyncForUndefinable, orElseAsyncForUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/to_nullable.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/to_nullable.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { toNullableFromUndefinable } from 'option-t/undefinable/to_nullable';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -16,3 +19,10 @@ for (const NULL_VALUE of [undefined, null]) {
         t.is(actual, null);
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.toNullableFromUndefinable, toNullableFromUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.toNullable, toNullableFromUndefinable);
+    t.is(UndefinableNamespace.toNullable, toNullableFromUndefinable);
+    t.is(UndefinableRootCompatV54.toNullableFromUndefinable, toNullableFromUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/to_plain_result/to_err.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/to_plain_result/to_err.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { toResultErrFromUndefinable } from 'option-t/undefinable/to_plain_result';
 import { nonNullableValueCaseListForSync } from '../../../utils.mjs';
 
@@ -22,4 +25,11 @@ test(`pass null`, (t) => {
     const actual = toResultErrFromUndefinable(null);
     t.true(isErr(actual), 'should be Err(undefined)');
     t.is(unwrapErr(actual), null, 'should the expected result');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.toResultErrFromUndefinable, toResultErrFromUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.toResultErr, toResultErrFromUndefinable);
+    t.is(UndefinableNamespace.toResultErr, toResultErrFromUndefinable);
+    t.is(UndefinableRootCompatV54.toResultErrFromUndefinable, toResultErrFromUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/to_plain_result/to_ok.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/to_plain_result/to_ok.test.mjs
@@ -1,6 +1,9 @@
 import test from 'ava';
 
 import { isOk, isErr, unwrapOk, unwrapErr } from 'option-t/plain_result/result';
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { toResultOkFromUndefinable } from 'option-t/undefinable/to_plain_result';
 import { nonNullableValueCaseListForSync } from '../../../utils.mjs';
 
@@ -22,4 +25,11 @@ test(`pass null`, (t) => {
     const actual = toResultOkFromUndefinable(null);
     t.true(isOk(actual), 'should be Ok(undefined)');
     t.is(unwrapOk(actual), null, 'should the expected result');
+});
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.toResultOkFromUndefinable, toResultOkFromUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.toResultOk, toResultOkFromUndefinable);
+    t.is(UndefinableNamespace.toResultOk, toResultOkFromUndefinable);
+    t.is(UndefinableRootCompatV54.toResultOkFromUndefinable, toResultOkFromUndefinable);
 });

--- a/packages/api_tests/__tests__/undefinable/operators/unwrap_or.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/unwrap_or.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { unwrapOrForUndefinable } from 'option-t/undefinable/unwrap_or';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -50,3 +53,10 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.unwrapOrForUndefinable, unwrapOrForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.unwrapOr, unwrapOrForUndefinable);
+    t.is(UndefinableNamespace.unwrapOr, unwrapOrForUndefinable);
+    t.is(UndefinableRootCompatV54.unwrapOrForUndefinable, unwrapOrForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/unwrap_or_else.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/unwrap_or_else.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { unwrapOrElseForUndefinable } from 'option-t/undefinable/unwrap_or_else';
 import { nonNullableValueCaseListForSync } from '../../utils.mjs';
 
@@ -66,3 +69,10 @@ test(`pass ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) => {
         });
     }
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.unwrapOrElseForUndefinable, unwrapOrElseForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.unwrapOrElse, unwrapOrElseForUndefinable);
+    t.is(UndefinableNamespace.unwrapOrElse, unwrapOrElseForUndefinable);
+    t.is(UndefinableRootCompatV54.unwrapOrElseForUndefinable, unwrapOrElseForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/unwrap_or_else_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/unwrap_or_else_async.test.mjs
@@ -1,5 +1,8 @@
 import test from 'ava';
 
+import * as UndefinableRoot from 'option-t/undefinable';
+import * as UndefinableRootCompatV54 from 'option-t/undefinable/compat/v54';
+import { Undefinable as UndefinableNamespace } from 'option-t/undefinable/namespace';
 import { unwrapOrElseAsyncForUndefinable } from 'option-t/undefinable/unwrap_or_else_async';
 import { nonNullableValueCaseListForAsync } from '../../utils.mjs';
 
@@ -73,3 +76,10 @@ for (const [src, def] of testcases) {
         );
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.is(UndefinableRoot.unwrapOrElseAsyncForUndefinable, unwrapOrElseAsyncForUndefinable);
+    t.is(UndefinableRoot.UndefinableOperator.unwrapOrElseAsync, unwrapOrElseAsyncForUndefinable);
+    t.is(UndefinableNamespace.unwrapOrElseAsync, unwrapOrElseAsyncForUndefinable);
+    t.is(UndefinableRootCompatV54.unwrapOrElseAsyncForUndefinable, unwrapOrElseAsyncForUndefinable);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/xor.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/xor.test.mjs
@@ -30,3 +30,7 @@ for (const { a, b, expected } of TABLE) {
         t.is(actual, expected, 'should be `' + String(expected) + '`');
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/zip.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/zip.test.mjs
@@ -30,3 +30,7 @@ for (const { a, b, expected } of TABLE) {
         t.deepEqual(actual, expected, 'should be `' + String(expected) + '`');
     });
 }
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/zip_with.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/zip_with.test.mjs
@@ -90,3 +90,7 @@ test(`should throw if the callback return ${NULL_VALUE_IN_THIS_TEST_CASE}`, (t) 
         },
     );
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});

--- a/packages/api_tests/__tests__/undefinable/operators/zip_with_async.test.mjs
+++ b/packages/api_tests/__tests__/undefinable/operators/zip_with_async.test.mjs
@@ -97,3 +97,7 @@ test(`should throw if the callback return ${NULL_VALUE_IN_THIS_TEST_CASE}`, asyn
         },
     );
 });
+
+test(`exported alias' identity check`, (t) => {
+    t.pass(true);
+});


### PR DESCRIPTION
Fix https://github.com/option-t/option-t/issues/2623