### PR TITLE
plain_result: Support const type param annotation for value projection

### DIFF
--- a/packages/api_typing_tests/__tests__/plain_result/core/create_err.test.ts
+++ b/packages/api_typing_tests/__tests__/plain_result/core/create_err.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
 import test from 'ava';
 
 import { expectTypeOf } from 'expect-type';
@@ -7,6 +8,17 @@ test('createErr', (t) => {
     const actual = createErr(Math.random());
 
     t.true(expectTypeOf(actual).toEqualTypeOf<Err<number>>());
+    t.true(expectTypeOf(actual).toExtend<Result<unknown, number>>());
+    t.true(expectTypeOf(actual).toExtend<Result<never, number>>());
+});
+
+test('const type param', (t) => {
+    const actual = createErr(123);
+
+    t.true(expectTypeOf(actual).toEqualTypeOf<Err<123>>());
+    t.true(expectTypeOf(actual).toExtend<Result<unknown, 123>>());
+    t.true(expectTypeOf(actual).toExtend<Result<never, 123>>());
+
     t.true(expectTypeOf(actual).toExtend<Result<unknown, number>>());
     t.true(expectTypeOf(actual).toExtend<Result<never, number>>());
 });

--- a/packages/api_typing_tests/__tests__/plain_result/core/create_ok.test.ts
+++ b/packages/api_typing_tests/__tests__/plain_result/core/create_ok.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
 import test from 'ava';
 
 import { expectTypeOf } from 'expect-type';
@@ -7,6 +8,17 @@ test('createOk', (t) => {
     const actual = createOk(Math.random());
 
     t.true(expectTypeOf(actual).toEqualTypeOf<Ok<number>>());
+    t.true(expectTypeOf(actual).toExtend<Result<number, unknown>>());
+    t.true(expectTypeOf(actual).toExtend<Result<number, never>>());
+});
+
+test('const type param', (t) => {
+    const actual = createOk(123);
+
+    t.true(expectTypeOf(actual).toEqualTypeOf<Ok<123>>());
+    t.true(expectTypeOf(actual).toExtend<Result<123, unknown>>());
+    t.true(expectTypeOf(actual).toExtend<Result<123, never>>());
+
     t.true(expectTypeOf(actual).toExtend<Result<number, unknown>>());
     t.true(expectTypeOf(actual).toExtend<Result<number, never>>());
 });

--- a/packages/option-t/src/plain_result/core/result.ts
+++ b/packages/option-t/src/plain_result/core/result.ts
@@ -102,7 +102,7 @@ export function isOk<T, E>(input: Result<T, E>): input is Ok<T> {
     return input.ok;
 }
 
-export function createOk<T>(val: T): Ok<T> {
+export function createOk<const T>(val: T): Ok<T> {
     const r: Ok<T> = {
         ok: true,
         val,
@@ -191,7 +191,7 @@ export function isErr<T, E>(input: Result<T, E>): input is Err<E> {
     return !input.ok;
 }
 
-export function createErr<E>(err: E): Err<E> {
+export function createErr<const E>(err: E): Err<E> {
     const r: Err<E> = {
         ok: false,
         // XXX:


### PR DESCRIPTION
Fix https://github.com/option-t/option-t/issues/2717

`createOk()` and `createErr()` are source of `Result<T, E>`. It's useful to supply `const` type param annotation to them and avoid to annotate everything in this repository as `const <type_param>` but get a benefit of it.

## Related Links

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters