### PR TITLE
ci: Stop to install npm-cli for trusted publishing

### DIFF
--- a/.github/workflows/publish_package_to_npm.yaml
+++ b/.github/workflows/publish_package_to_npm.yaml
@@ -20,12 +20,6 @@ jobs:
             - uses: ./.github/actions/prepare_ci
               with:
                   node-version: 24
-            # Trusted publishing requires npm CLI version 11.5.1 or later.
-            - name: Install latest npm
-              run: |
-                  echo "Current npm version: $(npm --version)"
-                  npm install -g npm@latest
-                  echo "Updated npm version: $(npm --version)"
             - run: pnpm install
             - run: make clean
             - run: make prepublish -j


### PR DESCRIPTION
Since pnpm v11, pnpm-cli implements its `publish` command natively. https://pnpm.io/ja/blog/releases/11.0