### PR TITLE
ci: Do not save cache if the current head is github's merge queue.

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -82,7 +82,7 @@ runs:
 
         - name: Save dependencies cache
           uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-          if: ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') }}
+          if: ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
           with:
               path: ${{ steps.pnpm-cache-dir.outputs.dir }}
               key: ${{ steps.cache-full-key.outputs.key }}


### PR DESCRIPTION
This follows up 818e190df8a6b0a2293442bc77ee38f11f1a382b

If the current head is in github's merge queue, it's meaningless to save a cache which will never restore again.

https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#startswith