### PR TITLE
retry(#2747): ci: Do not save cache if the current head is github's merge queue

### DIFF
--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -82,7 +82,7 @@ runs:
 
         - name: Check cache hit
           shell: bash
-          run: exit ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') }}
+          run: echo ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') }}
 
         - name: startsWith
           shell: bash

--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -88,3 +88,7 @@ runs:
           with:
               path: ${{ steps.pnpm-cache-dir.outputs.dir }}
               key: ${{ steps.cache-full-key.outputs.key }}
+
+        - name: Check cache hit
+            if: steps.cache.outputs.cache-hit != 'true'
+            run: exit 1

--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -80,19 +80,9 @@ runs:
           shell: bash
           run: pnpm install
 
-        - name: Save dependencies cache
-          uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-          # If the current head is in github's merge queue,
-          # it's meaningless to save a cache which will never restore again.
-          if: ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') && (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') != 'true') }}
-          with:
-              path: ${{ steps.pnpm-cache-dir.outputs.dir }}
-              key: ${{ steps.cache-full-key.outputs.key }}
-
         - name: Check cache hit
-          if: steps.pnpm-cache.outputs.cache-hit != 'true'
           shell: bash
-          run: exit 1
+          run: exit ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') }}
 
         - name: startsWith
           shell: bash

--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -82,7 +82,9 @@ runs:
 
         - name: Save dependencies cache
           uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-          if: ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') }}
+          # If the current head is in github's merge queue,
+          # it's meaningless to save a cache which will never restore again.
+          if: ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') && (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') != 'true') }}
           with:
               path: ${{ steps.pnpm-cache-dir.outputs.dir }}
               key: ${{ steps.cache-full-key.outputs.key }}

--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -90,5 +90,5 @@ runs:
               key: ${{ steps.cache-full-key.outputs.key }}
 
         - name: Check cache hit
-            if: steps.cache.outputs.cache-hit != 'true'
+            if: steps.pnpm-cache.outputs.cache-hit != 'true'
             run: exit 1

--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -90,11 +90,14 @@ runs:
               key: ${{ steps.cache-full-key.outputs.key }}
 
         - name: Check cache hit
-            if: steps.pnpm-cache.outputs.cache-hit != 'true'
-            run: exit 1
+          if: steps.pnpm-cache.outputs.cache-hit != 'true'\
+          shell: bash
+          run: exit 1
 
         - name: startsWith
-            run: echo ${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
+          shell: bash
+          run: echo ${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
 
         - name: Debug composed
-            run: echo ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') && (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') != 'true') }}
+          shell: bash
+          run: echo ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') && (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') != 'true') }}

--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -92,3 +92,9 @@ runs:
         - name: Check cache hit
             if: steps.pnpm-cache.outputs.cache-hit != 'true'
             run: exit 1
+
+        - name: startsWith
+            run: echo ${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
+
+        - name: Debug composed
+            run: echo ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') && (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') != 'true') }}

--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -82,7 +82,7 @@ runs:
 
         - name: Save dependencies cache
           uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-          if: ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') && !startsWith(github.ref, 'refs/heads/gh-readonly-queue/') }}
+          if: ${{ (steps.pnpm-cache.outputs.cache-hit != 'true') }}
           with:
               path: ${{ steps.pnpm-cache-dir.outputs.dir }}
               key: ${{ steps.cache-full-key.outputs.key }}

--- a/.github/actions/prepare_ci/action.yaml
+++ b/.github/actions/prepare_ci/action.yaml
@@ -90,7 +90,7 @@ runs:
               key: ${{ steps.cache-full-key.outputs.key }}
 
         - name: Check cache hit
-          if: steps.pnpm-cache.outputs.cache-hit != 'true'\
+          if: steps.pnpm-cache.outputs.cache-hit != 'true'
           shell: bash
           run: exit 1
 


### PR DESCRIPTION
This retry https://github.com/option-t/option-t/pull/2747

---

This follows up https://github.com/option-t/option-t/commit/818e190df8a6b0a2293442bc77ee38f11f1a382b

If the current head is in github's merge queue, it's meaningless to save a cache
which will never restore again.

https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#startswith