### PR TITLE
plain_result: Add typing test for `createOk`/`createErr`

### DIFF
--- a/packages/api_typing_tests/__tests__/__helpers__/mutable.ts
+++ b/packages/api_typing_tests/__tests__/__helpers__/mutable.ts
@@ -1,0 +1,3 @@
+export type Mutable<out T> = {
+    -readonly [P in keyof T]: T[P];
+};

--- a/packages/api_typing_tests/__tests__/plain_result/core/create_err.test.ts
+++ b/packages/api_typing_tests/__tests__/plain_result/core/create_err.test.ts
@@ -3,6 +3,7 @@ import test from 'ava';
 
 import { expectTypeOf } from 'expect-type';
 import { type Err, type Result, createErr } from 'option-t/plain_result/result';
+import type { Mutable } from '../../__helpers__/mutable.js';
 
 test('createErr', (t) => {
     const actual = createErr(Math.random());
@@ -21,4 +22,46 @@ test('const type param', (t) => {
 
     t.true(expectTypeOf(actual).toExtend<Result<unknown, number>>());
     t.true(expectTypeOf(actual).toExtend<Result<never, number>>());
+});
+
+test('const type param: object', (t) => {
+    interface Expect {
+        readonly a: 1;
+    }
+
+    type MutableExpect = Mutable<Expect>;
+
+    const actual = createErr({
+        a: 1,
+    });
+
+    t.true(expectTypeOf(actual).toEqualTypeOf<Err<Expect>>());
+    t.true(expectTypeOf(actual).not.toEqualTypeOf<Err<MutableExpect>>());
+
+    t.true(expectTypeOf(actual).toExtend<Result<unknown, Expect>>());
+    t.true(expectTypeOf(actual).toExtend<Result<never, Expect>>());
+
+    t.true(expectTypeOf(actual).toExtend<Result<unknown, MutableExpect>>());
+    t.true(expectTypeOf(actual).toExtend<Result<never, MutableExpect>>());
+});
+
+test('const type param: object: explicit instantiation', (t) => {
+    interface Expect {
+        a: 1;
+    }
+
+    type ReadonlyExpect = Readonly<Expect>;
+
+    const actual = createErr<Expect>({
+        a: 1,
+    });
+
+    t.true(expectTypeOf(actual).toEqualTypeOf<Err<Expect>>());
+    t.true(expectTypeOf(actual).not.toEqualTypeOf<Err<ReadonlyExpect>>());
+
+    t.true(expectTypeOf(actual).toExtend<Result<unknown, Expect>>());
+    t.true(expectTypeOf(actual).toExtend<Result<never, Expect>>());
+
+    t.true(expectTypeOf(actual).toExtend<Result<unknown, ReadonlyExpect>>());
+    t.true(expectTypeOf(actual).toExtend<Result<never, ReadonlyExpect>>());
 });

--- a/packages/api_typing_tests/__tests__/plain_result/core/create_ok.test.ts
+++ b/packages/api_typing_tests/__tests__/plain_result/core/create_ok.test.ts
@@ -3,6 +3,7 @@ import test from 'ava';
 
 import { expectTypeOf } from 'expect-type';
 import { type Ok, type Result, createOk } from 'option-t/plain_result/result';
+import type { Mutable } from '../../__helpers__/mutable.js';
 
 test('createOk', (t) => {
     const actual = createOk(Math.random());
@@ -21,4 +22,46 @@ test('const type param', (t) => {
 
     t.true(expectTypeOf(actual).toExtend<Result<number, unknown>>());
     t.true(expectTypeOf(actual).toExtend<Result<number, never>>());
+});
+
+test('const type param: object', (t) => {
+    interface Expect {
+        readonly a: 1;
+    }
+
+    type MutableExpect = Mutable<Expect>;
+
+    const actual = createOk({
+        a: 1,
+    });
+
+    t.true(expectTypeOf(actual).toEqualTypeOf<Ok<Expect>>());
+    t.true(expectTypeOf(actual).not.toEqualTypeOf<Ok<MutableExpect>>());
+
+    t.true(expectTypeOf(actual).toExtend<Result<Expect, unknown>>());
+    t.true(expectTypeOf(actual).toExtend<Result<Expect, never>>());
+
+    t.true(expectTypeOf(actual).toExtend<Result<MutableExpect, unknown>>());
+    t.true(expectTypeOf(actual).toExtend<Result<MutableExpect, never>>());
+});
+
+test('const type param: object: explicit instantiation', (t) => {
+    interface Expect {
+        a: 1;
+    }
+
+    type ReadonlyExpect = Readonly<Expect>;
+
+    const actual = createOk<Expect>({
+        a: 1,
+    });
+
+    t.true(expectTypeOf(actual).toEqualTypeOf<Ok<Expect>>());
+    t.true(expectTypeOf(actual).not.toEqualTypeOf<Ok<ReadonlyExpect>>());
+
+    t.true(expectTypeOf(actual).toExtend<Result<Expect, unknown>>());
+    t.true(expectTypeOf(actual).toExtend<Result<Expect, never>>());
+
+    t.true(expectTypeOf(actual).toExtend<Result<ReadonlyExpect, unknown>>());
+    t.true(expectTypeOf(actual).toExtend<Result<ReadonlyExpect, never>>());
 });


### PR DESCRIPTION
This follows up 6e5d10f64a24276861e062e40dc548a9f51df5dd https://github.com/option-t/option-t/pull/2718