### PR TITLE
Add homepage and bugs.url package metadata

### DIFF
--- a/packages/option-t/package.json
+++ b/packages/option-t/package.json
@@ -38,6 +38,10 @@
         "type": "git",
         "url": "git+https://github.com/option-t/option-t.git"
     },
+    "homepage": "https://github.com/option-t/option-t/tree/main/packages/option-t#readme",
+    "bugs": {
+        "url": "https://github.com/option-t/option-t/issues"
+    },
     "keywords": [
         "either",
         "maybe",


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `option-t`
- updates only `packages/option-t/package.json`

## Metadata added
- `homepage`: `https://github.com/option-t/option-t/tree/main/packages/option-t#readme`
- `bugs.url`: `https://github.com/option-t/option-t/issues`

## Validation
- parsed `packages/option-t/package.json` as JSON after the change
- confirmed the manifest still has `name: option-t`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package expose the project support/discovery information once the package is next released.