### PR TITLE
Prepare to upgrade `typescript` to v7.0

### DIFF
--- a/packages/api_typing_tests/package.json
+++ b/packages/api_typing_tests/package.json
@@ -5,9 +5,11 @@
     "version": "56.1.2",
     "license": "MIT",
     "scripts": {
-        "test": "tsc -p ./tsconfig.json --stableTypeOrdering"
+        "test:ts6": "tsc6 -p ./tsconfig.json --stableTypeOrdering",
+        "test:ts7": "tsc -p ./tsconfig.json --stableTypeOrdering"
     },
     "dependencies": {
+        "@typescript/typescript6": "catalog:",
         "expect-type": "catalog:",
         "option-t": "workspace:*",
         "typescript": "catalog:"

--- a/packages/test_module_node20/package.json
+++ b/packages/test_module_node20/package.json
@@ -5,9 +5,11 @@
     "version": "56.1.2",
     "license": "MIT",
     "scripts": {
-        "test": "tsc -p ./tsconfig.json --stableTypeOrdering"
+        "test:ts6": "tsc6 -p ./tsconfig.json --stableTypeOrdering",
+        "test:ts7": "tsc -p ./tsconfig.json --stableTypeOrdering"
     },
     "dependencies": {
+        "@typescript/typescript6": "catalog:",
         "option-t": "workspace:*",
         "typescript": "catalog:"
     }

--- a/packages/test_module_nodenext/package.json
+++ b/packages/test_module_nodenext/package.json
@@ -5,9 +5,11 @@
     "version": "56.1.2",
     "license": "MIT",
     "scripts": {
-        "test": "tsc -p ./tsconfig.json --stableTypeOrdering"
+        "test:ts6": "tsc6 -p ./tsconfig.json --stableTypeOrdering",
+        "test:ts7": "tsc -p ./tsconfig.json --stableTypeOrdering"
     },
     "dependencies": {
+        "@typescript/typescript6": "catalog:",
         "option-t": "workspace:*",
         "typescript": "catalog:"
     }

--- a/packages/test_module_resolution_bundler/package.json
+++ b/packages/test_module_resolution_bundler/package.json
@@ -5,9 +5,11 @@
     "version": "56.1.2",
     "license": "MIT",
     "scripts": {
-        "test": "tsc -p ./tsconfig.json --stableTypeOrdering"
+        "test:ts6": "tsc6 -p ./tsconfig.json --stableTypeOrdering",
+        "test:ts7": "tsc -p ./tsconfig.json --stableTypeOrdering"
     },
     "dependencies": {
+        "@typescript/typescript6": "catalog:",
         "option-t": "workspace:*",
         "typescript": "catalog:"
     }

--- a/packages/test_module_resolution_node16/package.json
+++ b/packages/test_module_resolution_node16/package.json
@@ -5,9 +5,11 @@
     "version": "56.1.2",
     "license": "MIT",
     "scripts": {
-        "test": "tsc -p ./tsconfig.json --stableTypeOrdering"
+        "test:ts6": "tsc6 -p ./tsconfig.json --stableTypeOrdering",
+        "test:ts7": "tsc -p ./tsconfig.json --stableTypeOrdering"
     },
     "dependencies": {
+        "@typescript/typescript6": "catalog:",
         "option-t": "workspace:*",
         "typescript": "catalog:"
     }

--- a/packages/test_module_resolution_node_next/package.json
+++ b/packages/test_module_resolution_node_next/package.json
@@ -5,9 +5,11 @@
     "version": "56.1.2",
     "license": "MIT",
     "scripts": {
-        "test": "tsc -p ./tsconfig.json --stableTypeOrdering"
+        "test:ts6": "tsc6 -p ./tsconfig.json --stableTypeOrdering",
+        "test:ts7": "tsc -p ./tsconfig.json --stableTypeOrdering"
     },
     "dependencies": {
+        "@typescript/typescript6": "catalog:",
         "option-t": "workspace:*",
         "typescript": "catalog:"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@typescript-eslint/parser':
       specifier: ^8.59.4
       version: 8.60.0
+    '@typescript/typescript6':
+      specifier: ^6.0.0
+      version: 6.0.1
     ava:
       specifier: ^8.0.1
       version: 8.0.1
@@ -102,6 +105,9 @@ importers:
 
   packages/api_typing_tests:
     dependencies:
+      '@typescript/typescript6':
+        specifier: 'catalog:'
+        version: 6.0.1
       expect-type:
         specifier: 'catalog:'
         version: 1.3.0
@@ -153,6 +159,9 @@ importers:
 
   packages/test_module_node20:
     dependencies:
+      '@typescript/typescript6':
+        specifier: 'catalog:'
+        version: 6.0.1
       option-t:
         specifier: workspace:*
         version: link:../option-t
@@ -162,6 +171,9 @@ importers:
 
   packages/test_module_nodenext:
     dependencies:
+      '@typescript/typescript6':
+        specifier: 'catalog:'
+        version: 6.0.1
       option-t:
         specifier: workspace:*
         version: link:../option-t
@@ -171,6 +183,9 @@ importers:
 
   packages/test_module_resolution_bundler:
     dependencies:
+      '@typescript/typescript6':
+        specifier: 'catalog:'
+        version: 6.0.1
       option-t:
         specifier: workspace:*
         version: link:../option-t
@@ -180,6 +195,9 @@ importers:
 
   packages/test_module_resolution_node16:
     dependencies:
+      '@typescript/typescript6':
+        specifier: 'catalog:'
+        version: 6.0.1
       option-t:
         specifier: workspace:*
         version: link:../option-t
@@ -189,6 +207,9 @@ importers:
 
   packages/test_module_resolution_node_next:
     dependencies:
+      '@typescript/typescript6':
+        specifier: 'catalog:'
+        version: 6.0.1
       option-t:
         specifier: workspace:*
         version: link:../option-t

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ catalog:
   '@reflink/reflink': ^0.1.19
   '@typescript-eslint/eslint-plugin': ^8.59.4
   '@typescript-eslint/parser': ^8.59.4
+  '@typescript/typescript6': ^6.0.0
   ava: ^8.0.1
   del-cli: ^7.0.0
   eslint: ^10.2.1

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -10,6 +10,16 @@
             "dependsOn": ["^build"]
         },
         "test": {
+            "dependsOn": [
+                // @prettier-ignore,
+                // "test:ts7", // FIXME: Enable this in #2772
+                "test:ts6"
+            ]
+        },
+        "test:ts7": {
+            "dependsOn": ["build"]
+        },
+        "test:ts6": {
             "dependsOn": ["build"]
         },
         "test:update-snapshots": {


### PR DESCRIPTION
Allow to test the compat between TS v6 and TS v7, We run typecheck test in both of them.

Fix https://github.com/option-t/option-t/issues/2777